### PR TITLE
introduced tags for CAM, CICE, CIME, and CLM

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,19 +1,19 @@
 [cam]
-tag = cam_cesm2_1_rel_05-Nor
+tag = cam_cesm2_1_rel_05-Nor_v1.0.0
 protocol = git
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam
 required = True
 
 [cice]
-tag = cice5_20181109-Nor
+tag = cice5_20181109-Nor_v1.0.0
 protocol = git
 repo_url = https://github.com/NorESMHub/CESM_CICE5
 local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_cesm2_1_rel_06-Nor
+tag = cime5.6.10_cesm2_1_rel_06-Nor_v1.0.0
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime
@@ -28,7 +28,7 @@ externals = Externals_CISM.cfg
 required = True
 
 [clm]
-tag = release-clm5.0.14-Nor
+tag = release-clm5.0.14-Nor_v1.0.0
 protocol = git
 repo_url = https://github.com/NorESMhub/ctsm
 local_path = components/clm


### PR DESCRIPTION
Modified Externals.cfg for CAM, CICE, CISM, and CLM : now refers to tags (instead of branches).