### PR TITLE
Noresm2

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,19 +1,19 @@
 [cam]
-tag = cam_cesm2_1_rel_05-Nor_v1.0.0
+tag = cam_cesm2_1_rel_05-Nor_v1.0.1
 protocol = git
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam
 required = True
 
 [cice]
-tag = cice5_20181109-Nor_v1.0.0
+tag = cice5_20181109-Nor_v1.0.1
 protocol = git
 repo_url = https://github.com/NorESMHub/CESM_CICE5
 local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_cesm2_1_rel_06-Nor_v1.0.0
+tag = cime5.6.10_cesm2_1_rel_06-Nor_v1.0.1
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime
@@ -51,7 +51,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = blom0_0_000
+tag = blom0_0_001
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/micom

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -25,7 +25,7 @@ protocol = git
 repo_url = https://github.com/ESCOMP/cism-wrapper
 local_path = components/cism
 externals = Externals_CISM.cfg
-required = True
+required = False
 
 [clm]
 tag = release-clm5.0.14-Nor_v1.0.0
@@ -48,7 +48,7 @@ protocol = svn
 repo_url = https://svn-ccsm-models.cgd.ucar.edu/pop2/release_tags
 local_path = components/pop
 externals = Externals_POP.cfg
-required = True
+required = False
 
 [blom]
 tag = blom0_0_000
@@ -69,7 +69,7 @@ tag = ww3_cesm2_1_rel_01
 protocol = svn
 repo_url = https://svn-ccsm-models.cgd.ucar.edu/ww3/release_tags
 local_path = components/ww3
-required = True
+required = False
 
 [externals_description]
 schema_version = 1.0.0


### PR DESCRIPTION
Updated tags for individual components : CAM, CICE, CIME, and BLOM.  These tags refer to code versions using the new ocean model name BLOM.

Switched to false the request to download CISM, POP, and WW3 (these components are not needed to run a pure NorESM compset).