### PR TITLE
BLOM/iHAMOCC updates

### DIFF
--- a/doc/configurations/experiments.rst
+++ b/doc/configurations/experiments.rst
@@ -242,34 +242,34 @@ Model resolution is set when the case is created. Below some common resolutions 
   
   <noresm_base>/cime/config/cesm/config_grids.xml
 
+
 Atmospheric grids
 ^^^^^^^^^^^^^^^^^
+::
 
+  f19_f19 - atm lnd 1.9x2.5
+  f09_f09 - atm lnd 0.9x1.25  
+  f09_f09_mg17
 
-| f19_f19 - atm lnd 1.9x2.5  
-| f09_f09 - atm lnd 0.9x1.25  
-| f09_f09_mg17
 
 Ocean grids
 ^^^^^^^^^^^
-Which ocean grid is recommended?
+Currently, BLOM supports three resolutions, nominal 2,1, and 1/4 degrees in a tripolar grid configuration:
+::
 
-| tnx1v1 tripole v1 1-deg grid  
-| tnx1v3 tripole v3 1-deg grid  
-| tn14(?)tripole v4 1-deg grid  tripole ocean grid  
-| tnx2v1 tripole v1 2-deg grid  
-| tx1v1 tripole v1 1-deg grid: testing proxy for high-res tripole ocean grids- do not use for scientific experiments  
+  tnx1v4   - tripolar ocn ice 1-degree grid  
+  tnx2v1   - tripolar ocn ice 2-degree grid  
+  tx0.25v4 - tripolar ocn ice 1/4-degree grid  
+
 
 Coupled
 ^^^^^^^
-| f09_tn11   - atm lnd 0.9x1.25, ocnice tnx1v1
-| f09_tn13   - atm lnd 0.9x1.25, ocnice tnx1v3
-| f09_tn14   - atm lnd 0.9x1.25, ocnice tnx1v4  [CMIP6 grid]
-| f09_tn0251 - atm lnd 0.9x1.25, ocnice tnx0.25v1
-| f09_tn0253 - atm lnd 0.9x1.25, ocnice tnx0.25v3
-| f19_tn11   - atm lnd 1.9x2.5, ocnice tnx1v1
-| f19_tn13   - atm lnd 1.9x2.5, ocnice tnx1v3
-| f19_tn14   - atm lnd 1.9x2.5, ocnice tnx1v4  [CMIP6 grid]
+::
+
+  f19_tn14   - atm lnd 1.9x2.5, ocnice tnx1v4  [CMIP6 grid, NorESM2-LM]  
+  f09_tn14   - atm lnd 0.9x1.25, ocnice tnx1v4  [CMIP6 grid, NorESM2-MM]  
+  f09_tn0254 - atm lnd 0.9x1.25, ocnice tnx0.25v4  
+
 
 Simulation period
 ''''''''''''''''''''''''''

--- a/doc/configurations/input.rst
+++ b/doc/configurations/input.rst
@@ -40,12 +40,12 @@ This AeroTab presentation https://github.com/NorESMhub/NorESM/blob/noresm2/doc/c
 Ocean specific input data
 ^^^^^
 
-In the OMIP-type experiments, the ocean is initialized from rest, and the initial ocean temperature and salinity are from the Polar Science Center Hydrographic Climatology (PHC) 3.0, updated from Steele et al. (2001). The initial condition file containing ocean temperature and salinity for the one-degree OMIP experiments is located at (on Fram) ::
+In case of a startup run (i.e. if the model is not re-started from a prvious simulation) the ocean is initialized from rest, and the initial ocean temperature and salinity are from the Polar Science Center Hydrographic Climatology (PHC) 3.0, updated from Steele et al. (2001). The initial condition files containing ocean temperature and salinity are located in the directory
+::
 
-  /cluster/shared/noresm/inputdata/ocn/micom/tnx1v4/20170601/inicon.nc
-  
-The file contains values for layered potential density (sigma: sigma2 - 1000), potential temperature (temp), salinity (saln) and thickness (dz):
+  /DIN_LOC_ROOT/ocn/blom/inicon/inicon_<gridspec>_<date>.nc,
 
+where DIN_LOC_ROOT is the base input data directory (depends on the machine; on fram it is /cluster/shared/noresm/inputdata), *gridspec* specifies the ocean grid used, and *date* specifies a date tag for the file. The files contains values for layered potential density (sigma), potential temperature (temp), salinity (saln) and layer thickness (dz):
 :: 
 
   dimensions:
@@ -57,17 +57,33 @@ The file contains values for layered potential density (sigma: sigma2 - 1000), p
           double temp(z, y, x) ;
           double saln(z, y, x) ;
           double dz(z, y, x) ;
+
+Boundary conditions for the ocean component (e.g. tidal dissipation, SSS climatologies for OMIP configuration) are located in 
 ::
 
+   /DIN_LOC_ROOT/ocn/blom/bndcon/,
 
+and grid specific information (grid input file, files defining ocean basins and sections) are located in 
+::
+
+   /DIN_LOC_ROOT/ocn/blom/grid/.
+   
+   
 Ocean carbon cycle specific input data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ocean carbon cycle in NorESM2 (iHAMOCC) requires three input data sets to run: 1) monthly climatological dust deposition based on Mahowald et al. (2005), 2) riverine inputs, which contain annual climatology (nomalized to year 2000) fluxes of organic and inorganic carbon and nutrient constituents based on the Global-NEWS2 model and other datasets (Mayorga et al., 2010; Hartmann, 2009; Chester, 1990), and 3) atmospheric nitrogen deposition, provided through the CMIP6 protocol in monthly deposition fields of wet or dry and oxidized or reduced nitrogen deposition rates, all of which are added to the nitrate pool in the top-most ocean layer.  
+The ocean carbon cycle in NorESM2 (iHAMOCC) is initialized from gridded observation based data sets for DIC, alkalinity, phosphate, nitrate, oxygen, and silica. These data sets have been provided by CMIP6-OMIP (Orr et al. 2017), and are located in the same directory as the BLOM initial conditions.
 
-By default, these external inputs are activated, but user can choose not to include riverine and nitrogen deposition by setting BLOM_RIVER_NUTRIENTS and BLOM_N_DEPOSITION to FALSE in user namelist (user_bl_blom) file.
+Further, iHAMOCC requires three input data sets specifying boundary conditions: 1) monthly climatological dust deposition based on Mahowald et al. (2006), 2) riverine inputs, which contain an annual climatology (normalized to year 2000) of fluxes of organic and inorganic carbon and nutrient constituents based on the Global-NEWS2 model and other datasets (Mayorga et al., 2010; Hartmann, 2009; Chester, 1990), and 3) atmospheric nitrogen deposition, provided through the CMIP6 protocol in monthly deposition fields of wet or dry and oxidized or reduced nitrogen deposition rates, all of which are added to the nitrate pool in the top-most ocean layer.  
 
-These datasets have been prepared for the ocean model (BLOM) grid configuration of ~1 degree resolution. For other resolutions, these files may need to be created and tested. 
+By default, these external inputs are activated, but the user can choose not to include riverine and nitrogen deposition by setting BLOM_RIVER_NUTRIENTS and BLOM_N_DEPOSITION to FALSE in in env_run.xml.
+
+While the initial conditions are interpolated by the model (using nearest neighbor interpolation), the boundary condition datasets need to be pre-interpolated to the ocean grid used. These data sets are available for 2, 1, and 1/4 degree resolution (the tnx2v1, tnx1v4, and tnx0.25v4 grids). Note however, that for running CMIP scenario simulations, specific N-deposition data sets are necessary. These might not be available for a given grid, so they may need to be created and tested. 
+
+
+Adding new inputfiles
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+All BLOM/iHAMOCC input file names are specified via namelist (including the full path name). If a user would like to use a different input file, it is recommended to place this file in the user's work directory, and specify the corresponding file name (icluding the full path) as a namelist option in user_nl_blom (see :ref:`omips`).
 
 
 References
@@ -93,7 +109,7 @@ Mayorga, E., Seitzinger, S. P., Harrison, J. A., Dumont, E., Beusen, A. H. W., B
 
 Meinshausen, M., Vogel, E., Nauels, A., Lorbacher, K., Meinshausen, N., Etheridge, D. M., Fraser, P. J., Montzka, S. A., Rayner, P. J., Trudinger, C. M., Krummel, P. B., Beyerle, U., Canadell, J. G., Daniel, J. S., Enting, I. G., Law, R. M., Lunder, C. R., O’Doherty, S., Prinn, R. G., Reimann, S., Rubino, M., Velders, G. J. M., Vollmer, M. K., Wang, R. H. J., and Weiss, R.: Historical greenhouse gas concentrations for climate modelling (CMIP6), Geoscientific Model Development, 10, 2057–2116, https://doi.org/10.5194/gmd-10-2057-2017, 2017.
 
+Orr, J. C., Najjar, R. G., Aumont, O., Bopp, L., Bullister, J. L., Danabasoglu, G., Doney, S. C., Dunne, J. P., Dutay, J.-C., Graven, H., Griffies, S. M., John, J. G., Joos, F., Levin, I., Lindsay, K., Matear, R. J., McKinley, G. A., Mouchet, A., Oschlies, A., Romanou, A., Schlitzer, R., Tagliabue, A., Tanhua, T., and Yool, A.: Biogeochemical protocols and diagnostics for the CMIP6 Ocean Model Intercomparison Project (OMIP), Geosci. Model Dev., 10, 2169–2199, https://doi.org/10.5194/gmd-10-2169-2017, 2017. 
+ 
 van Marle, M. J. E., Kloster, S., Magi, B. I., Marlon, J. R., Daniau, A.-L., Field, R. D., Arneth, A., Forrest, M., Hantson, S., Kehrwald, N. M., Knorr, W., Lasslop, G., Li, F., Mangeon, S., Yue, C., Kaiser, J. W., and van der Werf, G. R.: Historic global biomass burning emissions for CMIP6 (BB4CMIP) based on merging satellite observations with proxies and fire models (1750–2015), Geoscientific Model Development, 10, 3329–3357, https://doi.org/10.5194/gmd-10-3329-2017, 2017.
 
-Add new inputfiles
-^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/start.rst
+++ b/doc/start.rst
@@ -29,38 +29,31 @@ NorESM2 specific additions to CESM2 includes (but is not limited to):
 
   - Wind drift of snow
 - Ocean model : Isopycnic coordinate model BLOM 
-- Ocean biogeochemical model : iHAMOCC 
+- Ocean biogeochemical model : iHAMOCC
 
-  - Hamburg Model of Ocean Carbon Cycle (HAMOCC) adopted for use with isopycnic ocean model and further developed (Tjiputra et al. GMD, 2020)
+  - HAMburg Ocean Carbon Cycle model (HAMOCC) adopted for use with the isopycnic ocean model BLOM and further developed (Tjiputra et al. GMD, 2020)
 
 For a short description of the model components, please see :ref:`model-description`
 
 
-NorESM2 exists in four versions:
+NorESM2 exists in three versions:
 ++++++++++++++++
 
 - **NorESM2-MM**
    
   - 1 degree resolution for all model components
-  - CO2 concentration driven
    
 - **NorESM2-MM**
  
   - 2 degree resolution for the atmosphere and land components
   - 1 degree resolution for the ocean and sea-ice components
-  - CO2 concentration driven
   
 - **NorESM2-MH**
  
   - 1 degree resolution for the atmosphere and land components
   - 0.25 degree resolution for the ocean and sea-ice components
-  - CO2 concentration driven
  
-- **NorESM2-LME**
-    
-  - 2 degree resolution for the atmosphere and land components
-  - 1 degree resolution for the ocean and sea-ice components
-  - CO2 emission driven, used for interactive carbon-cycle studies
+
    
 
 
@@ -79,8 +72,7 @@ References
 ^^^^^^
 Seland, Ø., Bentsen, M., Seland Graff, L., Olivié, D., Toniazzo, T., Gjermundsen, A., Debernard, J. B., Gupta, A. K., He, Y., Kirkevåg, A., Schwinger, J., Tjiputra, J., Schancke Aas, K., Bethke, I., Fan, Y., Griesfeller, J., Grini, A., Guo, C., Ilicak, M., Hafsahl Karset, I. H., Landgren, O., Liakka, J., Onsum Moseid, K., Nummelin, A., Spensberger, C., Tang, H., Zhang, Z., Heinze, C., Iverson, T., and Schulz, M.: The Norwegian Earth System Model, NorESM2 – Evaluation of theCMIP6 DECK and historical simulations, Geosci. Model Dev. Discuss., https://doi.org/10.5194/gmd-2019-378, in review, 2020.
 
-Tjiputra, J. F., Schwinger, J., Bentsen, M., Morée, A. L., Gao, S., Bethke, I., Heinze, C., Goris, N., Gupta, A., He, Y., Olivié, D., Seland, Ø., and Schulz, M.: Ocean biogeochemistry in the Norwegian Earth System Model version 2 (NorESM2), Geosci. Model Dev. Discuss., https://doi.org/10.5194/gmd-2019-347, in review, 2020.
-
+Tjiputra, J. F., Schwinger, J., Bentsen, M., Morée, A. L., Gao, S., Bethke, I., Heinze, C., Goris, N., Gupta, A., He, Y.-C., Olivié, D., Seland, Ø., and Schulz, M.: Ocean biogeochemistry in the Norwegian Earth System Model version 2 (NorESM2), Geosci. Model Dev., 13, 2393–2431, https://doi.org/10.5194/gmd-13-2393-2020, 2020.
 
 Toniazzo, T., Bentsen, M., Craig, C., Eaton, B. E., Edwards, J., Goldhaber, S., Jablonowski, C., and Lauritzen, P. H.: Enforcing conservation of axial angular momentum in the atmospheric general circulation model CAM6, Geosci. Model Dev., 13, 685–705, https://doi.org/10.5194/gmd-13-685-2020, 2020.
 


### PR DESCRIPTION
I have corrected the statement that there are four NorESM2 versions. There are three; to run the model emission driven is an option, it does not make a model version. We have submitted all emission driven runs under the model ID NorESM2-LM.

I also corrected the HAMOCC acronym and did some minor edidts.

I have expanded and updated input.rst and omips.rst to reflect the most recent changes in input data structure and BLOM/iHAMOCC user namelist.