### PR TITLE
adding science_support grid information for NorESM2 CMIP6 compsets

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -254,103 +254,145 @@
   </compset>
 
   <!-- NorESM compset -->
+
+  <!-- Comment on function of "frc2" in NorESM compsets :
+
+    	There are two types of compsets for NorESM2 : the (i) ones without "frc2", and (ii) the ones with "frc2" in their name.
+	These compsets differ slightly in how atmospheric emission files are organized (but in a climatological sense they are very close).
+	The "frc2" compset have been introduced to avoid a problem of non-reproducibility on the fram HPC.  
+	The problem was that identical simulations setup without "frc2" started to divergence on average after 5 to 8 years into the simulations.i
+	With "frc2", we do not have that problem on fram HPC anaymore.
+
+	For the CMIP6 simulations submitted to ESGF, some have been done without "frc2", some with "frc2".
+	As a general rule :
+	(i) f09 resolution : all simulations have been done WITH frc2.
+	(ii) f19 resolution : 
+       		piControl + historical + perturbed historical (hist-aer, hist-GHG, hist-nat) have been done WITH frc2
+		scenarios + perturbed scenarions : have been done WITH frc2 -->
+
   <compset>
     <alias>N1850</alias>
     <!--lname>1850_CAM60%PTAERO_CLM50%BGC_CICE_BLOM_MOSART_SGLC_SWAV</lname-->
     <!--lname>1850_CAM60%PTAERO_CLM50%BGC-CROP_CICE_BLOM_MOSART_SGLC_SWAV</lname -->
     <!-- lname>1850_CAM60%NORESM_CLM50%BGC-CROP_CICE_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname -->
     <lname>1850_CAM60%NORESM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f09_tn14"/>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <!-- uses differently organized emission files : FRC2 -->
   <compset>
     <alias>N1850frc2</alias>
     <lname>1850_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f09_tn14"/>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>N1850esm</alias>
     <lname>1850_CAM60%NORESM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BPRPDMS</lname>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <!-- uses differently organized emission files : FRC2 -->
   <compset>
     <alias>N1850frc2esm</alias>
     <lname>1850_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BPRPDMS</lname>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NHIST</alias>
     <lname>HIST_CAM60%NORESM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f09_tn14"/>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <!--uses differently organized emission files : FRC2 -->
   <compset>
     <alias>NHISTfrc2</alias>
     <lname>HIST_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f09_tn14"/>
+    <science_support grid="f19_tn14"/>
   </compset>
 
    <compset>
     <alias>NHISTesm</alias>
     <lname>HIST_CAM60%NORESM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BPRPDMS</lname>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <!--uses differently organized emission files : FRC2 -->
   <compset>
     <alias>NHISTfrc2esm</alias>
     <lname>HIST_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BPRPDMS</lname>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NHISTpintcf</alias>
     <lname>HIST_CAM60%NORESM%PINTCF_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NHISTpiaer</alias>
     <lname>HIST_CAM60%NORESM%PIAER_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f19_tn14"/>
   </compset>
 
  <compset>
     <alias>NHISTpiaeroxid</alias>
     <lname>HIST_CAM60%NORESM%PIAEROXID_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NCO2x4cmip6</alias>
     <lname>1850_CAM60%NORESM%4xCO2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f09_tn14"/>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <!-- uses differently organized emission files : FRC2 -->
   <compset>
     <alias>NCO2x4cmip6frc2</alias>
     <lname>1850_CAM60%NORESM%FRC2%4xCO2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f09_tn14"/>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>N1PCTcmip6</alias>
     <lname>1850_CAM60%NORESM%1PCT_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f09_tn14"/>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <!-- uses differently organized emission files : FRC2 -->
   <compset>
     <alias>N1PCTcmip6frc2</alias>
     <lname>1850_CAM60%NORESM%FRC2%1PCT_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f09_tn14"/>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>N1850ghgonly</alias>
     <lname>1850_CAM60%NORESM%GHGONLY_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>N1850natonly</alias>
     <lname>1850_CAM60%NORESM%NATONLY_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>N1850aeroxidonly</alias>
     <lname>1850_CAM60%NORESM%AEROXIDONLY_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <!-- NorESM scenarios -->
@@ -358,31 +400,42 @@
   <compset>
     <alias>NSSP126frc2</alias>
     <lname>SSP126_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f09_tn14"/>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP126frc2ext</alias>
     <lname>SSP126_CAM60%NORESM%FRC2EXT_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP245frc2</alias>
     <lname>SSP245_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f09_tn14"/>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP370frc2</alias>
     <lname>SSP370_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f09_tn14"/>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP585frc2</alias>
     <lname>SSP585_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f09_tn14"/>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP585frc2ext</alias>
     <lname>SSP585_CAM60%NORESM%FRC2EXT_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f19_tn14"/>
+
   </compset>
 
   <!-- NorESM scenarios -->
@@ -390,16 +443,19 @@
   <compset>
     <alias>NSSP245frc2ghgonly</alias>
     <lname>1850_CAM60%NORESM%GHGONLY%SSP245%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP245frc2natonly</alias>
     <lname>1850_CAM60%NORESM%NATONLY%SSP245%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP245frc2aeroxidonly</alias>
     <lname>1850_CAM60%NORESM%AEROXIDONLY%SSP245%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>


### PR DESCRIPTION
indicated in cime_config/config_compsets which grids are supported for the NorESM2 CMIP6 compsets (science_support)