### PR TITLE
updated download_input.rst

### DIFF
--- a/doc/access/download_input.rst
+++ b/doc/access/download_input.rst
@@ -3,11 +3,12 @@
 Downloading inputdata
 ======================
 
-WILL BE UPDATED BY jan.griesfeller@met.no 
+Input datasets are needed to run the model. We don't recommend downloading the entire dataset because of the size (~1TB).
+Input datasets needed for a specific case and configuration will be automatically downloaded when a user builds a case. 
+We recommend to only have one input directory on a machine which is shared for all users. 
 
-Input datasets are needed to run the model. We don't recommend downloading the entire dataset because of the size (~TB). and since the input data sets needed for a specific case and configuration will be automatically downloaded when you build the case. We also recommend to only have one input directory on a machine which is shared for all users. 
-
-The input data needs to be stored in a local directory on the machine the model is build and run. The path to the local directory is set in <noresm-base>/cime/config/cesm/machines/config_machines.xml
+The input data needs to be stored in a local directory on the machine the model is build and run. The path to the local
+directory is set in <noresm-base>/cime/config/cesm/machines/config_machines.xml
 
 ::
 
@@ -15,17 +16,12 @@ The input data needs to be stored in a local directory on the machine the model 
   
 ::
 
-The download location with the highest priority is https://noresm.org/inputdata/ from where the downloading request 
-will be redirected to the real location.
-
-Make sure that the input data files are write-protected. 
+The main download location for input data is https://noresm.org/inputdata/ from where the downloading request 
+might be redirected to another location.
 
 
 NorESM specific inputdata
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-
-PLEASE ADD
-
 
 The recipe to download the complete NorESM2 code is based on how it is done for CESM. For more details please see
 https://escomp.github.io/CESM/release-cesm2/downloading_cesm.html


### PR DESCRIPTION
put in all info I know which is unfortunately very little.
NorESM specific input data has to described by somebody who actually runs the model.
Potential write protection of data is a general work organisation problem, not connected to the the input data itself. I don't think it belongs here since there are use cases where you want people to be able to update files.