### PR TITLE
added missing compset from featureCESM2.1.0-OsloDevelopment

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -425,6 +425,18 @@
   </compset>
 
   <compset>
+    <alias>NSSP370LOWNTCFfrc2</alias>
+    <lname>SSP370LOWNTCF_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f19_tn14"/>
+  </compset>
+
+  <compset>
+    <alias>NSSP370REFGHGLOWNTCFfrc2</alias>
+    <lname>SSP370REFGHGLOWNTCF_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f19_tn14"/>
+  </compset>
+
+  <compset>
     <alias>NSSP585frc2</alias>
     <lname>SSP585_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
     <science_support grid="f09_tn14"/>


### PR DESCRIPTION
Import of two compsets from old repository (branch = featureCESM2.1.0-OsloDevelopment) which had not yet been taken over.  These are :
NSSP370LOWNTCFfrc2
NSSP370REFGHGLOWNTCFfrc2
