### PR TITLE
Modfication of Externals.cfg for MOSART and RTM

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -36,9 +36,9 @@ externals = Externals_CLM.cfg
 required = True
 
 [mosart]
-tag = release-cesm2.0.03
+tag = release-cesm2.0.03-Nor_v1.0.0
 protocol = git
-repo_url = https://github.com/ESCOMP/mosart
+repo_url = https://github.com/NorESMhub/mosart
 local_path = components/mosart
 required = True
 
@@ -62,7 +62,7 @@ tag = release-cesm2.0.02
 protocol = git
 repo_url = https://github.com/ESCOMP/rtm
 local_path = components/rtm
-required = True
+required = False
 
 [ww3]
 tag = ww3_cesm2_1_rel_01


### PR DESCRIPTION
Suggested modfication of Externals.cfg : 
(1) MOSART is now using NorESMhub/MOSART (instead of ESCOMP/MOSART).  MOSART needed one modification to be able to run on nebual HPC, and therefore needed a fork on NorESMhub.
(2) required for RTM is set on false.