### PR TITLE
partial update of Externals.cfg + generation of Externals_test.cfg

### DIFF
--- a/Externals_test.cfg
+++ b/Externals_test.cfg
@@ -1,19 +1,19 @@
 [cam]
-tag = cam_cesm2_1_rel_05-Nor_v1.0.1
+tag = cam_cesm2_1_rel_05-Nor
 protocol = git
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam
 required = True
 
 [cice]
-tag = cice5_20181109-Nor_v1.0.1
+tag = cice5_20181109-Nor
 protocol = git
 repo_url = https://github.com/NorESMHub/CESM_CICE5
 local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_cesm2_1_rel_06-Nor_v1.0.1
+tag = cime5.6.10_cesm2_1_rel_06-Nor
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime
@@ -28,7 +28,7 @@ externals = Externals_CISM.cfg
 required = False
 
 [clm]
-tag = release-clm5.0.14-Nor_v1.0.1
+tag = release-clm5.0.14-Nor
 protocol = git
 repo_url = https://github.com/NorESMhub/ctsm
 local_path = components/clm
@@ -36,7 +36,7 @@ externals = Externals_CLM.cfg
 required = True
 
 [mosart]
-tag = release-cesm2.0.03-Nor_v1.0.0
+tag = release-cesm2.0.03-Nor
 protocol = git
 repo_url = https://github.com/NorESMhub/mosart
 local_path = components/mosart
@@ -51,7 +51,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = blom0_0_001
+tag = release-1.0
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom


### PR DESCRIPTION
partial update of Externals.cfg + generation of Externals_test.cfg aimed to do pre-tag testing

To use that External_test.cfg, on types :
./manage_externals/checkout_externals -e Externals_test.cfg 
(or)
./manage_externals/checkout_externals --externals Externals_test.cfg