### PR TITLE
update the NorESM diagnostic documentation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -178,3 +178,5 @@ epub_exclude_files = ['search.html']
 
 
 # -- Extension configuration -------------------------------------------------
+extensions = ['sphinxcontrib.bibtex']
+bibtex_bibfiles = ['references_noresm.bib']

--- a/doc/diagnostics/diag_run.rst
+++ b/doc/diagnostics/diag_run.rst
@@ -8,73 +8,86 @@ Introduction
 ============
 
 The NorESM Diagnostic Package:
-  is a NorESM model evaluation tool written with a set of scripts (bash, NCL etc) to provide a general evaluation and quick preview of the model performance with only one command line. This toolpackage works on the original model output and has NorESM-specific diagnostics.
+  is a NorESM model evaluation tool written with a set of scripts and command utilities (bash/cshrc, NCO, CDO and NCL etc) to provide a general evaluation and quick preview of the model performance with only one command line. This tool package works on the original model output and has NorESM-specific diagnostics.
 
 **The tool package consists of:**
 
-* CAM_DIAG: (NCAR's AMWG Diagnostics Package)
-* CLM_DIAG: (CESM Land Model Diagnostics Package)
-* CICE_DIAG: snow/sea ice volume/area
-* HAMOCC_DIAG: time series, climaotology, zonal mean, regional mean
-* BLOM_DIAG: time series, climatologies, zonal mean, fluxes, etc
+* **CAM_DIAG**: (Based on NCAR's `AMWG Diagnostics Package <http://www.cesm.ucar.edu/working_groups/Atmosphere/amwg-diagnostics-package/>`_)
+* **CLM_DIAG**: (Based on CLM `Land Model Diagnostics Package <http://www.cesm.ucar.edu/models/cesm1.2/clm/clm_diagpackage.html>`_)
+* **CICE_DIAG**: snow/sea ice volume/area
+* **HAMOCC_DIAG**: time series, climaotology, zonal mean, regional mean
+* **BLOM_DIAG**: time series, climatologies, zonal mean, fluxes, etc
 
-**NorESM diagnostics on GitHub**
+(See the `major changes to the NCAR's Diagnostics Package`_ at the bottom)
 
-The source codes of the NorESM diagnostics packages are developed and maintained in the Git version control repository:
+Installation
+============
+
+The source codes of the NorESM diagnostics packages are developed and maintained on the Github:
 https://github.com/NordicESMhub/noresmdiagnostics.
 
 And the observation dataset and grid files are hosted at:
 https://www.noresm.org/diagnostics, with a total size of ~100 GB.
 
-**NorESM diagnostics on NIRD**
+There are two options to use this package, as described in the following subsections:
 
-The full diagnostic package (including source files and data files) are currently hosted on NIRD: ``/projects/NS2345K/diagnostics/noresmdiagnostics``
-
-Installation
-============
-
-Use the preinstalled package
+Preinstalled package
 ----------------------------
 
-You don't need to install this diagnostic package, but you can call it as a command line directly on NIRD. As a prerequiste, you should have access permission to the NS2345K project on NIRD. There is no need to install the diagnostic packages, but just add the ``diag_run`` to your search path, or add it as an alias in ``$HOME/.bashrc``, 
-:: 
+The full diagnostic package (including source files and data files) are currently hosted on NIRD_: ::
 
-  alias diag_run=’/projects/NS2345K/diagnostics/noresmdiagnostics/bin’
+  NIRD:/projects/NS2345K/diagnostics/noresm
+
+.. _NIRD: https://documentation.sigma2.no/files_storage/nird.html 
+
+You don't need to install this diagnostic package, but you can call it as a command line directly on NIRD. As a prerequiste, you should have access permission to the NS2345K project on NIRD.
+
+One can either add the ``diag_run`` to your search path: ::
+
+  export PATH=$PATH:/projects/NS2345K/diagnostics/noresm/bin
   
-DO NOT make changes direclty in this preinstalled package.
+(assuming you are using Bash Shell)
 
-Clone and run your own copy
+or add it as an alias in ``$HOME/.bashrc``: :: 
+
+  alias diag_run="/projects/NS2345K/diagnostics/noresm/bin/diag_run"
+
+and ``source ~/.bashrc`` to make these changes take effect.
+
+(DO **NOT** make changes direclty in this preinstalled package; if you are willing to modify the code, refer to the next subsection below.)
+
+Fresh install
 ---------------------------
-If you wanto make some changes of the diagnostic package for your own purpuse or/and want to contribute to the development of it, you can installed it on NIRD under your personal folder or your own project area (i.e., /projects/NSxxxxK). Briefly, there are several steps to install it:
+If you want to change the code for your own purpose, you can installed it on NIRD under your HOME folder or your own project area (i.e., /projects/NSxxxxK). There are several steps to install it:
 
-1. Fork the NorESM Diagnostic Package ``Github repository <https://github.com/NordicESMhub/noresmdiagnostics>``_ to your own Github respository. For example, https://github.com/YOU_GITHUB_USERNAME/noresmdiagnostics
-2. Change to your preferred location, say DIAGROOT, where you want to install the tool, and ``git clone https://github.com/YOU_GITHUB_USERNAME/noresmdiagnostics``
-3. Change to $DIAGROOT/bin, and Link or download all the observation and grid data files.
+1. Fork the NorESM Diagnostic Package `Github repository <https://github.com/NordicESMhub/noresmdiagnostics>`_ to your own Github respository, e.g., https://github.com/YOU_GITHUB_USERNAME/noresmdiagnostics
+2. Change to your preferred location, denoted as $DIAGROOT, where you want to install the tool, and ``git clone https://github.com/YOU_GITHUB_USERNAME/noresmdiagnostics``
+3. Change to $DIAGROOT/noresmdiagnostics/bin, and link or download all the observation and grid data files.
   - If you are installing the tool on NIRD, you just need to link all the data to your clone by running the script ``linkdata.sh``, given you have access to the /project/NS2345K project
   - If you are not memember of NS2345K or you are installing it on platforms other than NIRD, you should download all the data to your clone by executing ``dloaddata.sh``. If you are not running it on NIRD, you should have CDO, NCO and NCL installed.
 4. Make changes to the code/scripts for your purpose. And call ``diag_run`` of your own clone.
-5. If you would like to contribute your function enhancements or bug fixes to the original diagnostic package, you should firstly make these changes in a new git branch, and commit the changes to your fork repository, then create an Issue at the `Github repository <https://github.com/NordicESMhub/noresmdiagnostics>`_, and finally make a ``pull`` request to the original Github repository to incorporate your changes.
+5. If you would like to contribute your function enhancements or bug fixes to the original diagnostic package, you should commit the changes to your fork repository, then create an Issue at the `Github repository <https://github.com/NordicESMhub/noresmdiagnostics>`_, and finally make a ``pull request``  tto the original Github repository to incorporate your changes.
 
-Run the diagnostic tool
-=======================
+Run the tool
+============
 
-Each package can be run/configured from the command line using the wrapper script for NorESM diagnosticsprogram ``diag_run``: 
+Each package can be run/configured from the command line using the wrapper script for NorESM diagnostic program ``diag_run``: 
 
 ::
 
-  ----------------------------------------------------------------------------- 
+  -------------------------------------------------
   Program:
-  /projects/NS2345K/noresm_diagnostics/bin/diag_run
-  Version: 2.0
+  /projects/NS2345K/diagnostics/noresm/bin/diag_run
+  Version: 2.1
   -------------------------------------------------
   Short description:
   A wrapper script for NorESM diagnostic packages.
-
+  
   Basic usage:
   diag_run -m [model] -c [test case name] -s [test case start yr] -e [test case end yr] # Run model-obs diagnostics
   diag_run -m [model] -c [test case name] -s [test case start yr] -e [test case end yr] -c2 [cntl case name] -s2 [cntl case start yr] -e2 [cntl case end yr] # Run model1-model2 diagnostics
-  nohup /projects/NS2345K/noresm_diagnostics/bin/diag_run -m [model] -c [test case name] -s [test case start yr] -e [test case end yr] &> out & # Run model-obs diagnostics in the background with nohup
-
+  nohup /projects/NS2345K/diagnostics/noresm/bin/diag_run -m [model] -c [test case name] -s [test case start yr] -e [test case end yr] &> out & # Run model-obs diagnostics in the background with nohup
+  
   Command-line options:
   -m, --model=MODEL                             Specify the diagnostics package (REQUIRED).
                                                 Valid arguments:
@@ -95,22 +108,32 @@ Each package can be run/configured from the command line using the wrapper scrip
   -i2, --input-dir2=DIR                         Specify the directory where the control case history files are located (OPTIONAL).
                                                 Default is --input-dir=/projects/NS2345K/noresm/cases
   -o, --output-dir=DIR                          Specify the directory where the package(s) the climatology and time-series files should be stored (OPTIONAL).
-                                                Default is --output-dir=/projects/NS2345K/noresm_diagnostics/out/$USER
+                                                Default is --output-dir=/projects/NS2345K/diagnostics/noresm/out/yanchun
   -p, --passive-mode                            Run the script in passive mode: the diagnostic script will be configured but not executed (OPTIONAL).
   -t, --type=TYPE                               Specify climatology or time series diagnostics (OPTIONAL): valid options are --type=climo and --type=time_series.
                                                 Default is to run both. Note that the time series are computed over the entire simulation.
   -w, --web-dir=DIR                             Specify the directory where the html should be published (OPTIONAL).
-                                                Default is --web-dir=/projects/NS2345K/www/noresm_diagnostics
+                                                Default is --web-dir=/projects/NS2345K/www/diagnostics/noresm/yanchun
   --no-atm                                      Run CLM diagnostics without CAM data. Must be used for offline CLM simulations.
- 
-
-::
-
+  
+  Examples:
+  diag_run -m all -c N1850_f19_tn11_exp1 -s 21 -e 50 # model-obs diagnostics of case=N1850_f19_tn11_exp1 (climatology between yrs 21 and 50) for all model components.
+  diag_run -m cam -c N1850_f19_tn11_exp1 -s 21 -e 50 -w /path/to/my/html # model-obs diagnostics in CAM, publish the html in /path/to/my/html.
+  diag_run -m blom -c N1850_f19_tn11_exp1 -t time_series # model-obs time-series diagnostics in BLOM for all years represented in the model output directory (/projects/NS2345K/noresm/cases/N1850_f19_tn11_exp1/ocn/hist/).
+  diag_run -m cice -c N1850_f19_tn11_exp1 -s 21 -e 50 -p # configure (but do not run) model-obs diagnostics for CICE.
+  diag_run -m clm -c N1850_f19_tn11_exp1 -s 21 -e 50 -i /input/directory1 -c2 N1850_f19_tn11_exp2 -s2 21 -e2 50 -i2 /input/directory2 # model1-model2 diagnostics for CLM with user-specified history file directories
+  diag_run -m blom -c N1850_f19_tn11_exp1 -s 21 -e 50 -t climo # model-obs climatology diagnostics (no time series) for BLOM:
+  diag_run -m cam -o /my/dir # install CAM diagnostics in /my/dir with minimal configuration.
+  diag_run -m blom,hamocc -c N1850OC_f19_tn11_exp1 -s 21 -e 50 # model-obs diagnostics for BLOM and HAMOCC.
+  diag_run -m clm -c N1850_f19_tn11_clmexp1 -s 71 -e 100 --no-atm # model-obs time-series diagnostics for an offline (uncoupled) CLM simulation.
+  diag_run -m hamocc -c N1850OC_f19_tn11_exp1 -s 31 -e 100 -t time_series # model-obs time-series diagnostics in HAMOCC between yrs 31 and 100.
+  
+  *** NOTE: '-m micom' should be used for the ocean component of NorESM version 1 ***
 
 Description
 ------------
 
-diag_run is a wrapper script, which is used to run the diagnostics for each NorESM component
+``diag_run`` is a wrapper script, which is used to run the diagnostics for each NorESM component
 (cam, clm, cice, blom, and hamocc). The diagnostic packages can be used to plot model results
 with respect to either observations (so-called model-obs diagnostics), or to another simulation
 (model1-model2 diagnostics). The diagnostics for the atmosphere (cam), land (clm) and sea-ice
@@ -122,11 +145,11 @@ Please note, the ocean component of the NorESM2, BLOM, is an updated version of 
 
 ``diag_run`` has two modes: 
 
--  an “active-mode”, for which diag_run runs the diagnostic scripts 
--  a “passive-mode”, for which diag_run only configures the scripts. 
+-  **active-mode**, for which ``diag_run`` runs the diagnostic scripts 
+-  **passive-mode**, for which ``diag_run`` only configures the scripts. 
 
-In the passive-mode the
-diagnostic scripts have to be run manually by the user. By default, diag_run is always in the active-mode, 
+In the **passive-mode** the diagnostic scripts have to be run manually by the user.
+By default, diag_run is always in the active-mode, 
 but switches into passive-mode if at least one of these two criteria are fulfilled:
 
 1. The user invokes the option -p (see below), or
@@ -135,49 +158,60 @@ but switches into passive-mode if at least one of these two criteria are fulfill
 Active-mode
 -------------
 
-If you want to use diag_run to run the full (climatology and time-series) diagnostics, the minimum
-requirement is to specify the options model, case_name, start_yr and end_yr
-(-m, -c, -s and -e), e.g.: ::
+If you want to use ``diag_run`` to run the full (climatology and time-series) diagnostics, the minimum
+requirement is to specify the options of *model*, *case_name*, *start_yr* and *end_yr*
+(-m, -c, -s and -e).
+
+.. _`Example 1`:
+
+Example 1: ::
 
   diag_run -m cam -c N1850_f19_tn14_191017 -s 21 -e 50
   
 This command runs atmospheric model-obs diagnostics of the case N1850_f19_tn14_191017 using
 a climatology between model years 21 and 50. It is assumed that the N1850_f19_tn14_191017
-history files are located in /projects/NS2345K/noresm/cases. By default, the resulting plots and html will be
+history files are located under */projects/NS2345K/noresm/cases*. By default, the resulting plots and html will be
 stored in ::
 
-  /projects/NS2345K/www/diagnostics/noresmdiagnostics/$USER/N1850_f19_tn14_191017/CAM_DIAG,
+  /projects/NS2345K/www/diagnostics/noresm/$USER/N1850_f19_tn14_191017/CAM_DIAG,
   
-or, if you specify to store them under a command folder, i.e. with ``-w /projects/NS2345K/www/diagnostics/noresmdiagnostics/common``. It links to links to the following URL: 
-http://ns2345k.web.sigma2.no/diagnostics/noresmdiagnostics/common/N1850_f19_tn14_191017/CAM_DIAG/yrs21to50-obs.html.
+or, if you specify to store them under a common folder, i.e. with ``-w /projects/NS2345K/www/diagnostics/noresm/common``. It links to the following URL: 
+http://ns2345k.web.sigma2.no/diagnostics/noresm/common/N1850_f19_tn14_191017/CAM_DIAG/yrs21to50-obs.html.
 
-The climatology and time-series files in /projects/NS2345K/diagnostics/noresmdiagnostics/out/$USER/CAM_DIAG (where $USER is your NIRD username).
+The climatology and time-series files under */projects/NS2345K/diagnostics/noresm/out/$USER/CAM_DIAG* (where $USER is your NIRD username).
 
-If you want to run model1-model2 diagnostics, you also need to specify case_name2, start_yr2 and
-end_yr2 (-c2, -s2, -e2) in addition, i.e.: ::
+If you want to run *model1-model2* diagnostics, you also need to specify *case_name2*, *start_yr2* and
+*end_yr2* (-c2, -s2, -e2) in addition.
 
-  diag_run -m cam -c N1850_f19_tn14_191017 -s 21 -e 50 -c2 B1850MICOM_f09_tn14_01 -s2 21 -e2 50
+.. _`Example 2`:
+
+Example 2: ::
+
+  diag_run -m cam -c N1850_f19_tn14_191017 -s 21 -e 50 \
+  -c2 B1850MICOM_f09_tn14_01 -s2 21 -e2 50
   
-would be the same as in Example 1 above, except for comparing N1850_f19_tn14_191017 to
-B1850MICOM_f09_tn14_01 instead of observations.
+would be the same as in Example 1 above, except for comparing *N1850_f19_tn14_191017* to
+*B1850MICOM_f09_tn14_01* instead of observations.
 
-In Example 1 and Example 2 the options ``-s`` and ``-e`` (as well as ``-s2``, ``-e2``) refer to the start and end
-years of the climatology. The time-series are calculated from all the history files in the case
-directory (input_dir). This is always the case unless the user invokes the option ``-t time_series``. If
-this option is invoked, start_yr and end_yr refer to the beginning and end of the time series instead
-of the climatology, hence:
+In `Example 1`_ and `Example 2`_ the options ``-s`` and ``-e`` (as well as ``-s2``, ``-e2``) refer to the start and end years of the climatology.
+The time-series are calculated from all the history files in the case directory (input_dir).
+This is always the case unless the user invokes the option ``-t time_series``.
+If this option is invoked, start_yr and end_yr refer to the beginning and end of the time series instead of the climatology,
+hence:
+
+.. _`Example 3`:
 
 Example 3: ::
 
   diag_run -m blom -c N1850_f19_tn14_blom_20200608 -t time_series -s 1 -e 10
 
-would produce blom time-series plots between years 1 and 20. Note that omitting start_yr and
-end_yr when the option ``-t time_series`` is invoked computes the time-series over the entire
+would produce blom time-series plots between years 1 and 20. Note that omitting *start_yr* and
+*end_yr* when the option ``-t time_series`` is invoked computes the time-series over the entire
 experiment (all history files in the case directory, input_dir): ::
 
    diag_run -m cam -c N1850_f19_tn14_191017 -t time_series
    
-``diag_run`` uses some template scripts for each of the model components. When diag_run is executed,
+``diag_run`` uses some template scripts for each of the model components. When ``diag_run`` is executed,
 these scripts are changed according to the user-specified settings and renamed with a time stamp.
 For example, if you run the blom diagnostics, the run script template (``blom_diag_template.sh``)
 will be renamed with a time-stamp as *blom_diag_YYMMDD_HHMMSS*.
@@ -188,76 +222,67 @@ stores information about changes in the diagnostics scripts invoked by the user,
 contains the standard output and error (i.e. what is shown in your terminal during runtime).
 When the diagnostics a component is finished the run scripts are copied to: ::
 
-  output_dir/$USER/model_diag/config/case_name/run_scripts
+  output_dir/$USER/XXX_DIAG/config/case_name/run_scripts
   
 and the config and output files to: ::
 
-  output_dir/$USER/model_diag/config/case_name/logs
+  output_dir/$USER/XXX_DIAG/config/case_name/logs
   
-Hence, for Example 1 above, the run scripts are saved in: ::
+Hence, for `Example 1`_ above, the run scripts are saved in: ::
 
-  /projects/NS2345K/diagnostics/noresmdiagnostics/out/ $USER/CAM_DIAG/config/N1850_f19_tn14_191017/run_scripts
+  /projects/NS2345K/diagnostics/noresm/out/$USER/CAM_DIAG/config/N1850_f19_tn14_191017/run_scripts
   
 and the config and out files in: ::
 
-  /projects/NS2345K/diagnostics/noresmdiagnostics/out/$USER/CAM_DIAG/config/N1850_f19_tn14_191017/logs
+  /projects/NS2345K/diagnostics/noresm/out/$USER/CAM_DIAG/config/N1850_f19_tn14_191017/logs
 
 Passive-mode
 -------------
-Another important property of diag_run is that it will only run the diagnostics if sufficient
-information has been provided by the user; otherwise it switches into passive-mode. diag_run will
+Another important property of ``diag_run`` is that it will only run the diagnostics if sufficient
+information has been provided by the user; otherwise it switches into passive-mode. ``diag_run`` will
 then configure the diagnostics scripts as much as possible (based on the information provided by the
 user), and also add information to the config file about which variables are still required to be
 modified by the user in order to run the diagnostic script. This option is particularly useful if you
 want to do some development work on the diagnostics scripts, or if you want to change any
-variables in the diagnostics scripts that are not included as an option in diag_run. Hence, if you run
+variables in the diagnostics scripts that are not included as an option in ``diag_run``. Hence, if you run
 the following command::
 
   diag_run -m clm
 
 
-the following will appear on the screen:
+the following will appear on the screen::
 
-::
-
-  [nird@login0 ~]$ /projects/NS2345K/diagnostics/noresmdiagnostics/diag_run -m clm
+  [nird@login0 ~]$ /projects/NS2345K/diagnostics/noresm/bin/diag_run -m clm
   -------------------------------------------------
   Program:
-  /projects/NS2345K/noresm_diagnostics/bin/diag_run
-  Version: 2.0
+  /projects/NS2345K/diagnostics/noresm/bin/diag_run
+  Version: 2.1
   -------------------------------------------------
-  -CHANGING DIAGNOSTICS DIRECTORY to
-  /projects/NS2345K/diagnostics/noresmdiagnostics/out/xxx/CLM_DIAG in lnd_template.csh
-  -CHANGING ROOT DIRECTORY FOR CODE AND DATA to
-  /projects/NS2345K/diagnostics/noresmdiagnostics/packages/CLM_DIAG in lnd_template.csh
+  -CHANGING DIAGNOSTICS DIRECTORY to /projects/NS2345K/diagnostics/noresm/out/yanchun/CLM_DIAG in lnd_template.csh
+  -CHANGING ROOT DIRECTORY FOR CODE AND DATA to /projects/NS2345K/diagnostics/noresm/packages/CLM_DIAG in lnd_template.csh
   -CHANGING INPUT DIR 1 to /projects/NS2345K/noresm/cases in lnd_template.csh
-  -CHANGING publish_html_root to /projects/NS2345K/www/diagnostics/noresmdiagnosticss in
-  lnd_template.csh
+  -CHANGING publish_html_root to /projects/NS2345K/www/diagnostics/noresm/yanchun in lnd_template.csh
   -SETTING UP TIME-SERIES DIAGNOSTICS FOR ENTIRE EXPERIMENT
-  CLM DIAGNOSTICS SUCCESSFULLY CONFIGURED in
-  /projects/NS2345K/diagnostics/noresmdiagnostics/out/xxx/CLM_DIAG
+  CLM DIAGNOSTICS SUCCESSFULLY CONFIGURED in /projects/NS2345K/diagnostics/noresm/out/yanchun/CLM_DIAG
   -------------------------------------------------
-  lnd_template.csh IS NOT RUNNING: NOT ALL REQUIRED VARIABLES HAVE BEEN CONFIGURED
-  (see /projects/NS2345K/diagnostics/noresmdiagnostics/out/xxx/CLM_DIAG/config.log).
+  lnd_template.csh IS NOT RUNNING: NOT ALL REQUIRED VARIABLES HAVE BEEN CONFIGURED (see /projects/NS2345K/diagnostics/noresm/out/yanchun/CLM_DIAG/config.log).
   -------------------------------------------------
   -------------------------------------------------
-  TOTAL diag_run RUNTIME: 0m2s
-  -CLM diagnostics: 0m2s
+  TOTAL diag_run RUNTIME: 0m1s
+  -CLM diagnostics: 0m1s
   -------------------------------------------------
-  DONE: fr. 20. april 15:37:42 +0200 2018
-
-::
+  DONE: Tue Dec 22 12:47:49 CET 2020
 
 The (semi-configured) run script has then been copied to
-/projects/NS2345K/diagnostics/noresmdiagnostics/out/<username>/CLM_DIAG/lnd_template.csh,
+/projects/NS2345K/diagnostics/noresm/out/<username>/CLM_DIAG/lnd_template.csh,
 and all information about the configuration is contained in
-/projects/NS2345K/diagnostics/noresmdiagnostics/out/<username>/CLM_DIAG/config.log
+/projects/NS2345K/diagnostics/noresm/out/<username>/CLM_DIAG/config.log
 
 Options
 -------
-diag_run options (flags) typically come in both short (single-letter) and long forms. A complete
-description of all options is given below in alphabetical order of the short option letter. When
-invoked without options, diag_run prints a table containing all options along with some examples
+``diag_run`` options (flags) typically come in both short (single-letter) and long forms.
+A complete description of all options is given below in alphabetical order of the short option letter.
+When invoked without options, ``diag_run`` prints a table containing all options along with some examples
 (see also below). ::
 
   -c case_name (-c1, --case, --case1)
@@ -272,32 +297,32 @@ diagnostics in active-mode. ::
 
   -e end_year (-e1,--end_yr,--end_yr1)
   
-If –type=time_series, this option refers to the end year of time-series for case_name. Otherwise, it
-refers to the end year of climatology. This option is optional if –type=time_series, but required for
-active-mode diagnostics if –type=climo or if type is not invoked. ::
+If ``--type=time_series``, this option refers to the end year of time-series for case_name. Otherwise, it
+refers to the end year of climatology. This option is optional if ``--type=time_series``, but required for
+active-mode diagnostics if ``--type=climo`` or if type is not invoked. ::
 
   -e2 end_year (--end_yr2)
   
-If –type=time_series, this option refers to the end year of time-series for case_name2. Otherwise, it
-refers to the end year of climatology. This option is optional if –type=time_series, but required for
-active-mode model1-model2 diagnostics if –type=climo or if type is not invoked. ::
+If ``--type=time_series``, this option refers to the end year of time-series for *case_name2*. Otherwise, it
+refers to the end year of climatology. This option is optional if ``--type=time_series``, but required for
+active-mode model1-model2 diagnostics if ``--type=climo`` or if type is not invoked. ::
 
   -i input_dir (-i1, --input-dir, --input-dir1)
   
 Name of the root directory of the monthly history files for case_name. For example, if your blom
-history files are located in /this/is/a/directory/case1/ocn/hist, this option should be set to
-input_dir=/this/is/a/directory. Default is input_dir=/projects/NS2345K/noresm/cases . ::
+history files are located in */this/is/a/directory/case1/ocn/hist*, this option should be set to
+*input_dir=/this/is/a/directory*. Default is *input_dir=/projects/NS2345K/noresm/cases* . ::
 
   -i2 input-dir2 (--input-dir2)
   
 Name of the root directory of the monthly history files for case_name2. Also here, default is
-input_dir2=/projects/NS2345K/noresm/cases . ::
+*input_dir2=/projects/NS2345K/noresm/cases* . ::
 
   -m model (--model)
 
 Name of the model you want to run the diagnostics for. Valid options are cam, clm, cice, blom,
 hamocc and all. This is the only option that is required for both the active and passive mode. If you
-invoke the “all” option, the cam, clm, cice, blom and hamocc diagnostics will be run
+invoke the "all" option, the cam, clm, cice, blom and hamocc diagnostics will be run
 subsequently. It is also possible to combine different models as you wish within this option: for
 example, if you only want to run cam and clm diagnostics, you can simply add the names of those
 models and separate them with a comma (-m cam,clm). ::
@@ -310,14 +335,14 @@ diagnostics. This option is necessary for offline CLM simulations. ::
   -o output_dir (--output_dir)
   
 Root directory where you want to store the output from the diagnostics (i.e. the climatology and
-time-series files). For example, if you set output_dir=/just/another/directory, the climatology and
+time-series files). For example, if you set *output_dir=/just/another/directory*, the climatology and
 time-series files from the blom diagnostics will be stored in::
 
   /just/another/directory/BLOM_DIAG/. 
   
 Default is::
 
-  output_dir=/projects/NS2345K/diagnostics/noresmdiagnostics/out/$USER
+  output_dir=/projects/NS2345K/diagnostics/noresm/out/$USER
   
 where $USER is your user name on NIRD. ::
 
@@ -328,19 +353,19 @@ have given sufficient information to run in active-mode, the diagnostic scripts 
 
  -s start_year (-s1,--start_yr,--start_yr1)
  
-If –type=time_series, this option refers to the start year of time-series for case_name. Otherwise, it
-refers to the start year of climatology. This option is optional if –type=time_series, but required for
-active-mode diagnostics if –type=climo or if type is not invoked. ::
+If ``--type=time_series``, this option refers to the start year of time-series for case_name. Otherwise, it
+refers to the start year of climatology. This option is optional if ``--type=time_series``, but required for
+active-mode diagnostics if ``--type=climo`` or if type is not invoked. ::
 
   -s2 start_year2 (--start_yr2)
   
-If –type=time_series, this option refers to the start year of time-series for case_name2. Otherwise, it
-refers to the start year of climatology. This option is optional if –type=time_series, but required for
-active-mode model1-model2 diagnostics if –type=climo or if type is not invoked. ::
+If ``--type=time_series``, this option refers to the start year of time-series for case_name2. Otherwise, it
+refers to the start year of climatology. This option is optional if ``--type=time_series``, but required for
+active-mode model1-model2 diagnostics if ``--type=climo`` or if type is not invoked. ::
 
   -t type (--type)
   
-Specifies if you only run climatology or time-series diagnostics: valid options are --type=climo and
+Specifies if you only run climatology or time-series diagnostics: valid options are ``--type=climo`` and
 --type=time_series. Default is to run both. ::
 
   -w webdir (--web-dir)
@@ -348,7 +373,7 @@ Specifies if you only run climatology or time-series diagnostics: valid options 
 Specifies the directory where the html should be stored. This directory should preferably be linked
 to a web server so that one can look at the results with a web browser. Default is::
 
-  --web-dir=/projects/NS2345K/www/diagnostics/noresmdiagnostics/
+  --web-dir=/projects/NS2345K/www/diagnostics/noresm/
   
 
 Examples
@@ -377,10 +402,9 @@ Configure (but do not run) model-obs diagnostics for CICE: ::
   
 Model1-model2 diagnostics for CLM with user-specified history file directories: ::
 
-  diag_run -m clm -c N1850_f19_tn11_exp1 -s 21 -e 50 -i /input/directory1 -c2
-  
-  
-N1850_f19_tn11_exp2 -s2 21 -e2 50 -i2 /input/directory2
+  diag_run -m clm -c N1850_f19_tn11_exp1 -s 21 -e 50 -i /input/directory1 \
+  -c2 N1850_f19_tn11_exp2 -s2 21 -e2 50 -i2 /input/directory2
+
 Model-obs climatology diagnostics (no time series) for BLOM: ::
 
   diag_run -m blom -c N1850_f19_tn14_blom_20200608 -s 1 -e 10 -t climo
@@ -400,10 +424,64 @@ Model-obs time-series diagnostics for an offline (uncoupled) CLM simulation: ::
 Model-obs time-series diagnostics in HAMOCC between yrs 31 and 100: ::
 
   diag_run -m hamocc -c N1850OC_f19_tn11_exp1 -s 31 -e 100 -t time_series
-  
 
+--------------------------------------------------------------------------------
 
+Major changes to the NCAR's Diagnostic Package:**
 
-move the tool package to /projects/NS2345K/diagnostics/noresmdiagnostics
+.. _`major changes to the NCAR's Diagnostics Package`:
 
-move the observational data and grid data to: /projects/NS2345K/www/diagnostics/inputdata/, and add tools to link or download the data
+The diagnostic tool package is based on NCAR's CAM and CLM Diagnostic Packages.
+
+*Changes to all components*
+
+The following major changes have been made in all diagnostic packages:
+
+- The calculation of the climatology has been improved, using the ncclimo oporator from nco.
+- The bash/csh variables publish_html and publish_html_root have been added in order to enable publication of the html on the NIRD web server.
+- There is now the option to calculate time series over the entire simulation (default). Hence, the start and end years of the time series must no longer be specified.
+- The bash/csh variable CLIMO_TIME_SERIES_SWITCH has been added in order to allow for diag_run to compute only climatology or time series if desired.
+- The environmental variable ncclimo_dir has been added in order to allow for diag_run to be run by cron.
+
+*CAM_DIAG specific major changes*
+
+- The CAM diagnostics (amwg) now calculate the annual and global mean time series of the net TOA radiation balance. The results are published on the web server together with the other figures.
+
+*CLM_DIAG specific major changes*
+
+- The amount of variables used in the time series calculations have been dramatically reduced in order to reduce time and computational resources
+- If time series or climatology is computed is now determined by the selected sets in the computation.
+
+*CICE_DIAG specific major changes*
+
+- The switch CNTL has been added in order to determine whether one or two cases should be plotted.
+
+*BLOM_DIAG (newly developed)*
+
+Has two modes: compare to the observations and anothor model run; includes diagnostics of:
+
+- Time series plots
+    * Sections transports
+    * Global averages
+    * Maximum AMOC
+    * Hovmoeller plots
+    * ENSO indices
+- Climatology plots
+    * Horizontal fields - annual means
+    * Horizontal fields - seasonal/monthly means
+    * Overturning circulation
+    * Zonal means (lat-depth)
+    * Equatorial cross sections
+    * Meridional fluxes (vertically integrated)
+
+*HAMOCC_DIAG (newly developed)*
+
+Has two modes: compare to the observations and anthor model run; includes diagnostics of:
+
+- Time series plots
+    * Global fluxes
+    * Global averages
+- Climatology plots
+    * Horizontal fields
+    * Zonal mean fields
+    * Regionally-averaged monthly climatologies


### PR DESCRIPTION
1. to reflect changes in:
* new path for the installed code and output of the diagnostic tool
* update of the CAM_DIAG part

2. the format and description of the documentation are improved.

As there are many changes in the documentation, one see the final format preview at the temporary site:
http://ns2345k.web.sigma2.no/people/yanchun/_build/diagnostics/diag_run.html

The update to the `conf.py` file is necessary for me to locally build the documentation.
Not sure this is the case for others. I can revert that change if find necessary.

This commit may also need to be merged to `noresm2` branch?

btw, the diagnostic [wiki page at met.no](https://wiki.met.no/noresm/modeldiagnostics) was updated for the last time. There will be no updates there in the future, but one need to redirect to the [latest NorESM documentation](https://noresm-docs.readthedocs.io/en/latest/diagnostics/diagnostics.html)