### PR TITLE
Update tags for CIME in Externals.cfg and tags for CAM and CLM in External_continuous_development.cfg

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -13,7 +13,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_cesm2_1_rel_06-Nor_v1.0.2
+tag = cime5.6.10_cesm2_1_rel_06-Nor_v1.0.3
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime

--- a/Externals_continuous_development.cfg
+++ b/Externals_continuous_development.cfg
@@ -1,5 +1,5 @@
 [cam]
-tag = cam_cesm2_1_rel_05-Nor
+tag = cam-Nor-dev
 protocol = git
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam
@@ -28,7 +28,7 @@ externals = Externals_CISM.cfg
 required = False
 
 [clm]
-tag = release-clm5.0.14-Nor
+tag = clm-Nor-dev
 protocol = git
 repo_url = https://github.com/NorESMhub/ctsm
 local_path = components/clm


### PR DESCRIPTION
Externals.cfg : updated tag for CIME to cime5.6.10_cesm2_1_rel_06-Nor_v1.0.3 to include machine settings for Betzy ; Externals_continuous_development.cfg : updated tag for CAM to cam-Nor-dev and for CLM to clm-Nor-dev