### PR TITLE
Externals.cfg : updated tag for CIME (include Betzy settings)

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -13,7 +13,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_cesm2_1_rel_06-Nor_v1.0.2
+tag = cime5.6.10_cesm2_1_rel_06-Nor_v1.0.3
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime


### PR DESCRIPTION
Externals.cfg : updated tag for CIME to cime5.6.10_cesm2_1_rel_06-Nor_v1.0.3 (to include Betzy settings)