### PR TITLE
Configuration allowing for the global 0.125 deg BLOM/CICE setup

### DIFF
--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -289,10 +289,8 @@
   </compset>
 
   <compset>
-    <alias>N1850frc2NOECO</alias>
-    <lname>1850_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f09_tn14"/>
-    <science_support grid="f19_tn14"/>
+    <alias>N1850frc2NOOBGC</alias>
+    <lname>1850_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -289,6 +289,13 @@
   </compset>
 
   <compset>
+    <alias>N1850frc2NOECO</alias>
+    <lname>1850_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f09_tn14"/>
+    <science_support grid="f19_tn14"/>
+  </compset>
+
+  <compset>
     <alias>N1850esm</alias>
     <lname>1850_CAM60%NORESM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BPRPDMS</lname>
     <science_support grid="f19_tn14"/>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -1926,6 +1926,45 @@
       </pes>
     </mach>
   </grid>
+
+  <grid name="a%0.9x1.25.+l%0.9x1.25.+oi%tnx0.125v4" >
+    <mach name="hexagon|vilje|fram|betzy">
+      <pes pesize="any" compset="CAM60%NORESM.+CLM50%BGC-CROP.+CICE.+BLOM">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>1536</ntasks_atm>
+          <ntasks_lnd>96</ntasks_lnd>
+          <ntasks_rof>256</ntasks_rof>
+          <ntasks_ice>1440</ntasks_ice>
+          <ntasks_ocn>1532</ntasks_ocn>
+          <ntasks_glc>256</ntasks_glc>
+          <ntasks_wav>256</ntasks_wav>
+          <ntasks_cpl>1024</ntasks_cpl>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_cpl>1</nthrds_cpl>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>96</rootpe_ice>
+          <rootpe_ocn>1536</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_cpl>0</rootpe_cpl>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
+
   <!--/djlo-->
 
   <!--grid name="a%0.9x1.25.+l%0.9x1.25.+oi%gx1" >


### PR DESCRIPTION
This pull request introduces the BLOM 1/8 deg (tnx0125) to NorESM, companion pull requests are made to the components. 
To test the configuration we introduced a new compset and PES settings.

The component-specific pull requests are:
CIME: https://github.com/NorESMhub/cime/pull/25
BLOM: https://github.com/NorESMhub/BLOM/pull/76
CICE: https://github.com/NorESMhub/CESM_CICE5/pull/5
CTSM/CLM: https://github.com/NorESMhub/CTSM/pull/6

Tested configurations: N1850frc2NOECO_f09_tnx0125v4, NOINY_T62_tn01254 on Betzy

!Note! from the companion CIME pull request: to run on Betzy, one also needs to change either config/cesm/machines/config_compilers.xml or Macros.make in a case folder, so that FFLAGS includes: -mcmodel medium option.