### PR TITLE
Fix some formatting errors in platforms.rst

### DIFF
--- a/doc/configurations/platforms.rst
+++ b/doc/configurations/platforms.rst
@@ -8,7 +8,7 @@ HPC platforms
 
 Below is a list of platforms where NorESM2 has been installed, including platform specific intructions. 
 
-<noresm-base>: the name of the folder where the model code has been downloaded (cloned from git)
+   <noresm-base> : the name of the folder where the model code has been downloaded (cloned from git)
 
 The configurations files with the platform specific settings are found in ::
   
@@ -27,11 +27,11 @@ Input data is stored in /cluster/shared/noresm/inputdata/
 
 Apply for membership in NorESM shared data storage (manager: mben@norceresearch.no) for access to the folder.
 
-The run and archive directories are stored /cluster/work/users/<user_name>/
+The run and archive directories are stored in /cluster/work/users/<user_name>/
 
 Create a new case: ::
 
-    ./create_newcase –case ../../../cases/<casename> --mach fram –-res <resolution> --compset <compset_name> --project <project_name> --user-mods-dir <user_mods_dir> --run-unsupported  
+    ./create_newcase --case ../../../cases/<casename> --mach fram --res <resolution> --compset <compset_name> --project <project_name> --user-mods-dir <user_mods_dir> --run-unsupported
 
 
 Betzy @ Sigma2
@@ -48,21 +48,21 @@ The run and archive directories are stored /cluster/work/users/<user_name>/
 
 Create a new case: ::
 
-    ./create_newcase –case ../../../cases/<casename> --mach betzy –-res <resolution> --compset <compset_name> --project <project_name> --user-mods-dir <user_mods_dir> --run-unsupported  
+    ./create_newcase --case ../../../cases/<casename> --mach betzy --res <resolution> --compset <compset_name> --project <project_name> --user-mods-dir <user_mods_dir> --run-unsupported
 
 Setting number of nodes on Betzy
 -----------------
-In fully coupled setup, for grid f19_tn14 and f09_tn14, various processors configurations are added and can be used by setting --pecount= S, L, M or X1
+In fully coupled setup, for grid f19_tn14 and f09_tn14, various processors configurations are added and can be used by setting ``--pecount`` = S, L, M or X1
 when creating a new case.
 
-For NorESM2-MM, using grid f09_tn14, `--pecount` will give the following number of nodes: ::
+For NorESM2-MM, using grid f09_tn14, ``--pecount`` will give the following number of nodes: ::
 
     S = 4
     M = 9
     L = 15
     X1 = 17
 
-and for NorESM2-LM, using grid f19_tn14, `--pecount` it will give the following number of nodes: ::
+and for NorESM2-LM, using grid f19_tn14, ``--pecount`` it will give the following number of nodes: ::
 
     S = 4
     M = 8
@@ -149,7 +149,7 @@ Input data is stored in /nobackup/forsk/noresm/inputdata/
 
 The run and archive directories are stored /nobackup/forsk/<user_name>/
 
-Before configuring and compiling the model, add export LMOD_QUIET=1 to your .bashrc
+Before configuring and compiling the model, add ``export LMOD_QUIET=1`` to your .bashrc
 
 ::
 
@@ -162,7 +162,7 @@ Create a new case:
 
 ::
 
-    ./create_newcase –case ../../../cases/<casename> --mach nebula –-res <resolution> --compset <compset_name> --project <project_name> --user-mods-dir <user_mods_dir> --run-unsupported  
+    ./create_newcase --case ../../../cases/<casename> --mach nebula --res <resolution> --compset <compset_name> --project <project_name> --user-mods-dir <user_mods_dir> --run-unsupported
 
 ::
 
@@ -208,7 +208,7 @@ Create a new case:
 
 ::
 
-./create_newcase –case ../../../cases/<casename> -mach triolith –res <resolution> -compset <compset_name> -pecount M -ccsm_out <NorESM_ouput_folder>
+    ./create_newcase --case ../../../cases/<casename> --mach triolith --res <resolution> --compset <compset_name> --pecount M --ccsm_out <NorESM_ouput_folder>
 
 ::
 


### PR DESCRIPTION
- Changed "link" (single `) to "quote" (double ``) for ``--pecount``
- Fixed some double dash (--) formatting in quoted shell commands

I'm not sure what to quote and what to leave as plain text. It would be good to have some common styling guidelines at some point.