### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This repository has the following NorESM branches:
 
 * **noresm2** - contains NorESM2.0.X documentation, code and configurations as used for most NorESM2-LM and NorESM2-MM CMIP6 simulations, with tags:
 
-  - release-noresm2.0.4 - Release of NorESM2.0.4 9th of April 2020, available to reproduce CMIP6 results of NorESM2. Additional Fram and Betzy settings included.
+  - release-noresm2.0.4 - Release of NorESM2.0.4 9th of April 2021, available to reproduce CMIP6 results of NorESM2. Additional Fram and Betzy settings included.
   - release-noresm2.0.3 - Release of NorESM2.0.3 7th of April 2021, available to reproduce CMIP6 results of NorESM2. Betzy settings included 
   - release-noresm2.0.2 - Release of NorESM2.0.2 20th of July 2020, available to reproduce CMIP6 results of NorESM2
   - release-noresm2.0.1 - NorESM2 version, initial preliminary release of CMIP6 version, April  2020 


### PR DESCRIPTION
Just notice an error in the readme of NorESM. issue #258

release-noresm2.0.4 - Release of NorESM2.0.4 9th of April 2020, available to reproduce CMIP6 results of NorESM2. Additional Fram and Betzy settings included.
Should be

release-noresm2.0.4 - Release of NorESM2.0.4 9th of April 2021, available to reproduce CMIP6 results of NorESM2. Additional Fram and Betzy settings included.