### PR TITLE
Test templates for github issues.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: TomasTorsvik
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: NorESM documentation FAQ
+    url: https://noresm-docs.readthedocs.io/en/latest/faq/faq.html
+    about: FAQ page for NorESM
+  - name: NorESM home page
+    url: https://www.noresm.org
+    about: Latest news about NorESM

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,17 @@
+---
+name: Documentation
+about: Suggest changes in the documentation.
+title: ''
+labels: documentation
+assignees: TomasTorsvik
+
+---
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -1,0 +1,10 @@
+---
+name: General issue
+about: Used for general issues, not covered by other templates.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+


### PR DESCRIPTION
This should create issue templates for NorESM. If it doesn't work, this feature can be enabled through the "Settings" menu.

NOTE: This pull request will change the behavior of "Issues" by creating an additional menu to select type of issue. We might want to just have a single issue template instead, or just stay with the default blank issue as starting point. If so, this pull request should be reversed.