### PR TITLE
Make issue templates more relevant for NorESM.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,25 +8,25 @@ assignees: TomasTorsvik
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+Please provide a clear and concise description of what the bug is.
+ - NorESM version:
+ - HPC platform:
+ - Compiler (if applicable):
+ - Compset (if applicable):
+ - Resolution (if applicable):
+ - Error message (if applicable):
 
 **To Reproduce**
 Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+1. 
+2. 
+3. 
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
-
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -8,7 +8,7 @@ assignees: TomasTorsvik
 ---
 
 **Describe a problem and/or suggest an improvement**
- - Something wrong in the documentation?
+ - Something incorrect or unclear in the documentation?
  - Something should be added to the documentation?
  - Something should be removed from the documentation?
  - Something should be re-structured in the documentation?

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -7,11 +7,12 @@ assignees: TomasTorsvik
 
 ---
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Describe a problem and/or suggest an improvement**
+ - Something wrong in the documentation?
+ - Something should be added to the documentation?
+ - Something should be removed from the documentation?
+ - Something should be re-structured in the documentation?
+ - Suggest a Q&A for the FAQ?
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,13 +8,12 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+A clear and concise description of what the problem is.
 
-**Describe the solution you'd like**
+**Describe the solution you would like to see**
 A clear and concise description of what you want to happen.
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+ - Would you be able to work on this solution yourself?
+ - How can the NorESM development team assist you?
 
 **Additional context**
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Should also set assignees at some point, but that should be discussed first. I think these changes should be fairly uncontroversial.