### PR TITLE
Docfix basic use

### DIFF
--- a/doc/configurations/experiments.rst
+++ b/doc/configurations/experiments.rst
@@ -69,14 +69,16 @@ For an overview of the compsets provided for CESM2, please see: http://www.cesm.
 
 
 Creating your own compset
-'''''''''''''''''
-The essential file to edit for a new coupled NorESM compset is :: 
+'''''''''''''''''''''''''
+The essential file to edit for a new coupled NorESM compset is
+::
 
-  <noresm_base>/cime_config/config_compsets.xml
+    <noresm_base>/cime_config/config_compsets.xml
   
-and for a new AMIP NorESM compset is :: 
+and for a new AMIP NorESM compset is
+::
 
-  <noresm_base>/components/cam/cime_config/config_compsets.xml
+    <noresm_base>/components/cam/cime_config/config_compsets.xml
   
   
 **Coupled simulation** 
@@ -91,7 +93,7 @@ This examples shows how to simply add the "N1850frc2" compset to ``config_compse
 where 
 
 * ``<alias>COMPSETNAME</alias>`` sets the compsets name used when building a new case, make sure to use a new and unique name
-* '_' is used as a separator between model components: ``_<MODEL>
+* '_' is used as a separator between model components: ``_<MODEL>``
 * '%' is used to to set components-specific configurations 
 
 So for the N1850frc2 compset, the different parts of the lname have the following meaning:
@@ -112,7 +114,9 @@ So for the N1850frc2 compset, the different parts of the lname have the followin
 - BGC%BDRDDMS
    - ocean biogeochemistry model iHAMOCC run with interactive DMS
 
-The details of the compset i.e. which models components and component-specific configurations to use are set in ``<lname>1850_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>``
+The details of the compset i.e. which models components and component-specific configurations to use are set in
+::
+    <lname>1850_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
 
 It is possible to use the long name (lname) to select a compset then creating a new case.  
 
@@ -126,7 +130,7 @@ For details about AMIP simulation compsets, please see :ref:`amips`
 Resolution and grids
 ''''''''''''
 
-The model resolution is set when the case is created (with the --res option). Below some common resolutions are listed. 
+The model resolution is set when the case is created (with the ``--res`` option). Below some common resolutions are listed. 
 
 **Atmospheric grids**
 ::
@@ -160,27 +164,20 @@ A complete list of model grids can be found here::
 Supported grids
 '''''''''''''
 
-Most compsets contain an entries listing which which grid(s) are scientifically supported for that compset ::
+Most compsets contain an entries listing which which grid(s) are scientifically supported for that compset
+::
 
-<science_support grid="xxx"/> fields
+    <science_support grid="xxx"/> fields
 
-When a compset has a scientifically-supported grid, you can create a new case (with the create_newcase script) without having to use the option ``--run-unsupported``. If the compset does not list any scientifically-supported grids, or if you want to use a grid configuration is not included in the definition of the compset, the ::
+When a compset has a scientifically-supported grid, you can create a new case (with the **create_newcase** script) without having to use the option ``--run-unsupported``. If the compset does not list any scientifically-supported grids, or if you want to use a grid configuration is not included in the definition of the compset, the ::
 
   --run-unsupported
 
-option is required when a case is created or the create_newcase script will fail.
-
-
-
-
-
-
-
-
+option is required when a case is created or the **create_newcase** script will fail.
 
 
 User modifications (usermods) 
-''''''''''''''''''
+'''''''''''''''''''''''''''''
 Several configuration options are available in the user modification (usermod) directories under ``<noresm_base>/cime_config/usermods_dirs/``. The sets of usermods contain pre-defined user namelists for the atmosphere (cam) and land (clm) components that have been used for specific experiments, such as the CMIP6 DECK experiments. Within the user namelists, the lists of output variables and output frequencies has been modified and/or extended with additional output variables. In addition, the usermodes include one SourceMod (``SourceMods/src.cam/preprocessorDefinitions.h``) which  defines whether AEROFFL and AEROCOM are activated to produce extra aerosol diagnostics (for more details about the aerosol diagnostics see :ref:`aerosol_output`)
 
 The usermods under ``<noresm_base>/cime_config/usermods_dirs/`` include::
@@ -255,12 +252,12 @@ If you want to ensure your case is ready for submission, you can run ::
   
 which will:
 
-- Ensure that all of the env xml files are in sync with the locked files
+- Ensure that all of the ``env_*.xml`` files are in sync with the locked files
 - Create namelists (thus verifying that there will be no problems with namelist generation)
 - Ensure that the build is complete
 
 Running this is completely optional: these checks will be done
-automatically when running case.submit. However, you can run this if you
+automatically when running **case.submit**. However, you can run this if you
 want to perform these checks without actually submitting the case.
 
 As a last step, remember to copy restart files to run directory if you are running a branch run or a hybrid run.

--- a/doc/configurations/newbie-guide.rst
+++ b/doc/configurations/newbie-guide.rst
@@ -17,59 +17,53 @@ Create a new case
 --------------------
 
 The **create_newcase** script is an excecutable python script located in:
-
 ::
 
   <noresm-base>/cime/scripts/
 
-::
-
 The script for creating a new case takes several command line arguments as input to know how to configure your case.
 Some of the most important arguments are as follows:
 
-  - ``-case`` defines a casename of your choice and created a folder by that name in <noresm-base>/cases/.
+  - ``--case`` defines a casename of your choice and creates a folder by that name. The argument respects absolute and relative paths (e.g. ``--case ../../cases/<casename>``).
 
-  - ``-mach`` defines the machine you will run the model on. The model NorESM2 has been configured to be run on a set of different machines (see list at :ref:`platforms`). If you are running the model on a machine not listed you will need to configure the model beyond this newbie guide. 
+  - ``--mach`` defines the machine you will run the model on. The model NorESM2 has been configured to be run on a set of different machines (see list at :ref:`platforms`). If you are running the model on a machine not listed you will need to configure the model beyond this newbie guide. 
 
-  - ``-res`` defines the resolution of your run. See :ref:`experiments` for more details.
+  - ``--res`` defines the resolution of your run. See :ref:`experiments` for more details.
 
-  - ``-compset`` defines what compset you will be using. A list of compsets for fully-coupled configurations can be found in the file <noresm_base>/cime_config/config_compsets.xml (see :ref:`amips` for compsets for AMIP-type simulations)
+  - ``--compset`` defines what compset you will be using. A list of compsets for fully-coupled configurations can be found in the file *<noresm_base>/cime_config/config_compsets.xml* (see :ref:`amips` for compsets for AMIP-type simulations)
 
-To investigate the full list of arguments, enter the <noresm_base>/cmie/scripts folder and run create_newcase with the --help argument:
+To investigate the full list of arguments, enter the *<noresm_base>/cime/scripts/* folder and run **create_newcase** with the ``--help`` argument:
 ::
     cd <noresm_base>/cime/scripts/
-  ./create_newcase --help
+    ./create_newcase --help
 
   
-To create a new case, enter the scripts directory and run the create_newcase scripts:
-:: 
-  cd <noresm_base>/cime/scripts/
-  ./create_newcase --case ../../cases/$CASENAME --mach $MACHINE --res f19_g16 --compset $COMPSET
+To create a new case, enter the scripts directory and run the **create_newcase** scripts:
+::
+    cd <noresm_base>/cime/scripts/
+    ./create_newcase --case ../../cases/$CASENAME --mach $MACHINE --res f19_g16 --compset $COMPSET
 
-You have now created the case folder <noresm_base>/cases/$CASENAME! Go to the case folder to start configuring your experiment.
+You have now created the case folder *<noresm_base>/cases/$CASENAME*! Go to the case folder to start configuring your experiment.
 
 More advanced examples
-++++++++
-The following example creates a case (test1910_1) on the machine Fram:
-
+++++++++++++++++++++++
+The following example creates the case *test1910_1* on the machine Fram:
 ::
 
-    ./create_newcase --case ../../cases/test1910_1 --compset N1850 --res f19_tn14 --machine fram --project snic2019-1-2 --user-mods-dir cmip6_noresm_DECK 
+    ./create_newcase --case ../../cases/test1910_1 --compset N1850 --res f19_tn14 --machine fram --project snic2019-1-2 --user-mods-dir cmip6_noresm_DECK --run-unsuported 
 
-Here we use the N1850 compset, which configures the case as a 1850 pre-industrial control simulation. Note that we use the argument **--run-unsupported**, which required if the grid resolution is not supported in the compset (see :ref:`experiments`), **--project** to set the id of the project used in the batch system accounting on Fram, **--user-mods-dir**  to set the path to a folder containing files that will further configure your case (like user namelists, shell scripts with xmlchange commands or SourceMods).
+Here we use the *N1850* compset, which configures the case as a 1850 pre-industrial control simulation.  The argument ``--project`` should correspond to the id of the project used in the batch system accounting on Fram. The argument ``--user-mods-dir`` provides the path to a folder containing files that will further configure your case (like user namelists, shell scripts with xmlchange commands or SourceMods). The default location for this folder is under *<noresm_base>/cime_config/usermods_dirs/*. Note that we use the argument ``--run-unsupported``, which is required if the grid resolution is not supported in the compset (see :ref:`experiments`).
 
-
-The following example creates a case (also called test1910_1), but on the machine Tetralith::
+The following example creates a case (also called *test1910_1*), but on the machine Tetralith:
 ::
 
     ./create_newcase --case ../../cases/test1910_1 --walltime 24:00:00 --compset N1850 --res f19_tn14 --machine tetralith --project snic2019-1-2 --output-root /proj/bolinc/users/${USER}/NorESM2/noresm2_out
     
-Note that here we use the argument **--output-root**, which is only required if the noresm_run_dir (the running directory of the mode) differs from default running directory <path_to_run_dir>/noresm/ 
+Note that here we use the argument ``--output-root``, which is only required if the *noresm_run_dir* (the running directory of the mode) differs from default running directory *<path_to_run_dir>/noresm/*. 
 
 Configure the case
 ---------------------
-The case folder `<noresm_base>/cases/$CASENAME/`` is where you configure your case by changing enviroment files (such as the <noresm_base>/cases/$CASENAME/env_run.xml file;see :ref:`experiment_environments`), changing the user namelists for the different model components (files named ``user_nl_$COMP`` where $COMP is a model component such as ``cam``), or even add your own code changes to ``SourceMods/src.$COMP/``. But for now we stick to the standard out-of-the-box set up and configure the case as follows:
-
+The case folder *<noresm_base>/cases/$CASENAME/* is where you configure your case by changing enviroment files (such as the *<noresm_base>/cases/$CASENAME/env_run.xml* file; see :ref:`experiment_environments`), changing the user namelists for the different model components (files named ``user_nl_$COMP`` where $COMP is a model component such as ``cam``), or even add your own code changes to ``SourceMods/src.$COMP/``. But for now we stick to the standard out-of-the-box set up and configure the case as follows:
 ::
 
   cd <noresm_base>/cases/$CASENAME

--- a/doc/configurations/newbie-guide.rst
+++ b/doc/configurations/newbie-guide.rst
@@ -50,9 +50,9 @@ More advanced examples
 The following example creates the case *test1910_1* on the machine Fram:
 ::
 
-    ./create_newcase --case ../../cases/test1910_1 --compset N1850 --res f19_tn14 --machine fram --project snic2019-1-2 --user-mods-dir cmip6_noresm_DECK --run-unsuported 
+    ./create_newcase --case ../../cases/test1910_1 --compset N1850 --res f19_tn14 --machine fram --project snic2019-1-2 --user-mods-dir cmip6_noresm_DECK 
 
-Here we use the *N1850* compset, which configures the case as a 1850 pre-industrial control simulation.  The argument ``--project`` should correspond to the id of the project used in the batch system accounting on Fram. The argument ``--user-mods-dir`` provides the path to a folder containing files that will further configure your case (like user namelists, shell scripts with xmlchange commands or SourceMods). The default location for this folder is under *<noresm_base>/cime_config/usermods_dirs/*. Note that we use the argument ``--run-unsupported``, which is required if the grid resolution is not supported in the compset (see :ref:`experiments`).
+Here we use the *N1850* compset, which configures the case as a 1850 pre-industrial control simulation.  The argument ``--project`` should correspond to the id of the project used in the batch system accounting on Fram. The argument ``--user-mods-dir`` provides the path to a folder containing files that will further configure your case (like user namelists, shell scripts with xmlchange commands or SourceMods). The default location for this folder is under *<noresm_base>/cime_config/usermods_dirs/*.
 
 The following example creates a case (also called *test1910_1*), but on the machine Tetralith:
 ::


### PR DESCRIPTION
- Suggest to remove the comment about "--run-unsupported" in the newbie-guide part. The example doesn't need the "-run-unsupported" flag, and a description of "--run-unsupported" is included in the "experiments" file.
- Some other minor edits in newbie-guide and experiments files