### PR TITLE
Issue templates: Change assigned people for reviewing issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: bug
-assignees: TomasTorsvik
+assignees: monsieuralok
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -3,7 +3,7 @@ name: Documentation
 about: Suggest changes in the documentation.
 title: ''
 labels: documentation
-assignees: TomasTorsvik
+assignees: adagj
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
+labels: good-to-have
 assignees: hgoelzer
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: ''
 labels: ''
-assignees: ''
+assignees: hgoelzer
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -3,7 +3,7 @@ name: General issue
 about: Used for general issues, not covered by other templates.
 title: ''
 labels: ''
-assignees: ''
+assignees: oyvindseland
 
 ---
 


### PR DESCRIPTION
The assigned people for reviewing issues is based on information I got from @adagj . In this setup there is only one person assigned in each template, so I have removed myself. If this was not the intention, I am happy to be assigned to one or more of the issues. In any case, I think the default reviewers should have a free hand to suggest other people as reviewers for specific issues that they handle.