### PR TITLE
Doc update from noresm2

### DIFF
--- a/doc/access/download_code.rst
+++ b/doc/access/download_code.rst
@@ -18,9 +18,9 @@ You can obtain the code using the command-line git client on the appropriate mac
   git clone https://github.com/NorESMhub/NorESM.git <noresm-base> 
   
 
-where <noresm-base> is the name of the directory where the latest version of the released code will be stored. You can replace <noresm-base> with the directory name you like. 
+where *<noresm-base>* is the name of the directory where the latest version of the released code will be stored. You can replace *<noresm-base>* with the directory name you like. 
 
-Enter the <noresm-base> folder::
+Enter the *<noresm-base>* folder ::
 
    cd <noresm-base>
 
@@ -44,27 +44,40 @@ And check which branch you are using::
 To use another version of the code, you can check out a specific tag or a branch.
 
 
-Check out a specific NorESM branch, eg NorESM2.0.1
-+++++++++++++++
+Check out a specific NorESM branch, e.g. NorESM2.0.1
+++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-List all available tags::
+List all available tags ::
 
   > git tag --list 
   
 
-To check out a specific tag, use **git checkout <tag-name>** where tag-name is a tag for the list, for instance release-noresm2.0.1::
+To check out a specific tag, use **git checkout <tag-name>** where *<tag-name>* is a tag for the list, for instance *release-noresm2.0.1* ::
 
   > git checkout release-noresm2.0.1 
 
-List all available branches::
+List all available branches ::
 
   > git branch --all              
 
-To check out a specific branch, for instance noresm2::
+To check out a specific branch, for instance *noresm2* ::
 
   > git checkout -b noresm2 origin/noresm2 
   
 You can now inspect which tag or branch you are using by invoking the **git branch** command again. You can also inspect the commits log by invoking the **git log** command (to for instance only see the 3 commits, apply the **-n 3** option). 
+
+
+NorESM releases configured for specific HPC platforms
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Machine configurations for specific HPC platforms have been integrated in different releases of NorESM, depending on when the HPC platforms became available. The following table shows which release introduced support for a specific platform. Please see :ref:`platforms` for more details.
+
++--------------------+-------------------------+
+| **HPC platform**   | **NorESM release**      |
++--------------------+-------------------------+
+| **Fram**           | *release-noresm2.0.0*   |
++--------------------+-------------------------+
+| **Betzy**          | *release-noresm2.0.3*   |
++--------------------+-------------------------+
 
 
 Manage externals
@@ -74,42 +87,38 @@ Then you need to launch the download::
 
    ./manage_externals/checkout_externals  [this will take one to a few minutes ...]
 
-this will use the repositories, tags, branches as specified in Externals.cfg (see `Configure Externals.cfg`_ for its manipulation)
+this will use the repositories, tags, branches as specified in **Externals.cfg** (see `Configure Externals.cfg`_ for its manipulation)
 
-**Known SVN-related errors**:
+The *checkout_externals* script will read the configuration file called **Externals.cfg** and will download all the external component models and CIME into */path/to/<noresm-base>*.
 
-If you run into several SVN-related errors when launching the model, you may want to try to change required=True to required=False for pop2 and ww3 in Externals.cfg. POP2 and WW3 are not needed in NorESM2. Then try again.
+Now you have a complete copy of the NorESM code in the directory *<noresm-base>*.  At this point you can enter the subdirectory *<noresm-base>/cime/scripts/* and start creating a case! (see :ref:`experiments`)
 
-When accessing svn repositories with ./manage_externals/checkout_externals for the first time on a new machine, the download of the svn repository might not work. This can be solved by doing a manual checkout without `--quiet`, e.g.: ::
+**Please note that if you checkout a new branch or tag, you will need to rerun checkout_externals in order to download the correct version of the model code**
+
+
+Confirm successful download of all components
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+To confirm a successful download of all components, you can run checkout_externals with the status flag ``-S`` to show the status of the externals or ``--logging`` to get a log of reported errors (if any): ::
+
+  ./manage_externals/checkout_externals -S             [-S shows status of externals]
+  ./manage_externals/checkout_externals --logging      [write log of errors in manage_externals.log]
+
+
+Known SVN-related errors
+^^^^^^^^^^^^^^^^^^^^^^^^
+Some model components are maintained under SVN version control instead of git version control. If you run into several SVN-related errors when launching the model, you may want to try to change ``required=True`` to ``required=False`` for the model components POP2 and WW3 in **Externals.cfg**. POP2 and WW3 are not needed in NorESM2. Then try again.
+
+When accessing svn repositories with **./manage_externals/checkout_externals** for the first time on a new machine, the download of the svn repository might not work. This can be solved by doing a manual checkout without ``--quiet``, e.g.: ::
 
     svn checkout https://svn-ccsm-models.cgd.ucar.edu/ww3/release_tags/ww3_cesm2_1_rel_01/cluster/projects/nn9560k/$USER/NorESMbittest/NorESM2.0/NorESM/components/ww3
     
 accept with "(p)" (permanently). The next time, downloading svn repositories should go smoothly.
 
-**To confirm a successful download of all components**, you can run checkout_externals with the status flag -S to show the status of the externals or --logging to get a log of reported errors (if any):
-
-::
-
-  ./manage_externals/checkout_externals -S             [-S shows status of externals]
-  ./manage_externals/checkout_externals --logging      [write log of errors in manage_externals.log]
-
-::
-
-
-The checkout_externals script will read the configuration file called Externals.cfg and will download all the external component models and CIME into /path/to/<noresm-base>.
-
-Now you have a complete copy of the NorESM code in the directory <noresm-base>.  Now you can to the subdirectory cime/scripts and start creating a case! (see :ref:`experiments`)
-
-**Please note that if you checkout a new branch or tag, you will need to rerun checkout_externals in order to download the correct version of the model code**
-
-Betzy
-+++++++++
-Please checkout tag NorESM2.0.3 or subsequent tags in order to run NorESM on the HPC platform Betzy. Please see :ref:`platforms` for more details.   
 
 Configure Externals.cfg
 ++++++++++++
 
-The Externals.cfg file contains code blocks that specify what model components to include in the NorESM build, where the source code for each component is located, and what verision of the model component to use. The file can be modified to use another repository, fork, branch or tag or release for any of the model components. The following example is for the land component, which in this case points to a version of the Community Terrestrial Systems Model (CTSM), which includes the Community Land Model (CLM)
+The **Externals.cfg** file contains code blocks that specify what model components to include in the NorESM build, where the source code for each component is located, and what verision of the model component to use. The file can be modified to use another repository, fork, branch or tag or release for any of the model components. The following example is for the land component, which in this case points to a version of the Community Terrestrial Systems Model (CTSM), which includes the Community Land Model (CLM)
 
 ::
 
@@ -152,10 +161,9 @@ branch
 hash
   the git hash to checkout from the repository.
 
-NOTE: one and only one of 'tag', 'branch' or 'hash' must be supplied. The supplied string will be parsed to a 'git checkout' command, but the the keyword determines what checks will be applied to the supplied string before parsing.
+**NOTE:** one and only one of 'tag', 'branch' or 'hash' must be supplied. The supplied string will be parsed to a 'git checkout' command, but the the keyword determines what checks will be applied to the supplied string before parsing.
 
 See more info here: 
 https://github.com/ESCOMP/CESM/blob/master/README.rst
 
 
-.

--- a/doc/access/download_input.rst
+++ b/doc/access/download_input.rst
@@ -16,8 +16,11 @@ directory is set in <noresm-base>/cime/config/cesm/machines/config_machines.xml
   
 ::
 
-The main download location for input data is https://noresm.org/inputdata/ from where the downloading request 
-might be redirected to another location.
+The main download location for input data is:
+  
+  https://noresm.org/inputdata/
+
+from where the downloading request might be redirected to another location.
 
 
 NorESM specific inputdata

--- a/doc/configurations/clm.rst
+++ b/doc/configurations/clm.rst
@@ -6,16 +6,15 @@ Land and river run off
 CLM5
 ------
 
-The land model used in NorESM2 is the Community Land Model version 5 (CLM5):
-http://www.cesm.ucar.edu/models/clm/
-
-
-Specific questions about CLM can be addressed Lei Cai, email: leca@norceresearch.no
+The land model used in NorESM2 is the Community Land Model version 5 (`CLM5 <http://www.cesm.ucar.edu/models/clm/>`_). Specific questions about CLM can be addressed to Hui Tang (email: hui.tang@geo.uio.no) or Kjetil Aas (email: k.s.aas@geo.uio.no).
 
 CLM5 model configurations available in NorESM2
 ^^^^^^
+The version of CLM5 used by NorESM2 can be found from Externals.cfg (see `here <https://noresm-docs.readthedocs.io/en/noresm2/access/download_code.html#configure-externals-cfg>`_ for a detailed explanation). 
+
 CLM5 can be run with a prognostic crop model with prognostic vegetation state and active biogeochemistry. 
 The global crop model is on in BGC default configuration with 8 temperate and tropical crop types and has the capability to dynamically simulate crop management and crop management change through time. 
+
 The BGC-CROP option is used in all NorESM2 CMIP6 experiments and is activated in the compset by::
 
   CLM50%BGC-CROP
@@ -35,7 +34,7 @@ The current state of the atmospheric component, CAM6-Nor, at a given time step i
 
 - 2. The land model then updates the soil and snow hydrology calculations based on these fluxes. These fields are passed to the atmosphere. The albedos sent to the atmosphere are for the solar zenith angle at the next time step but with surface conditions from the current time step.
 
-From CLM5 user guide: https://escomp.github.io/ctsm-docs/versions/release-clm5.0/html/tech_note/Ecosystem/CLM50_Tech_Note_Ecosystem.html#atmospheric-coupling
+From the CLM5 `user guide <https://escomp.github.io/ctsm-docs/versions/release-clm5.0/html/tech_note/Ecosystem/CLM50_Tech_Note_Ecosystem.html#atmospheric-coupling>`_. 
 
 
 CLM5 surface data
@@ -52,15 +51,12 @@ Required surface data for each land grid cell include:
 - peat area fraction
 - peak month of agricultural burning. Optional surface data include crop irrigation and managed crops.
 
-From CLM5 user guide: https://escomp.github.io/ctsm-docs/versions/release-clm5.0/html/tech_note/Ecosystem/CLM50_Tech_Note_Ecosystem.html#surface-data:
+From the CLM5 `user guide <https://escomp.github.io/ctsm-docs/versions/release-clm5.0/html/tech_note/Ecosystem/CLM50_Tech_Note_Ecosystem.html#surface-data>`_.
 
-**Steps to create a complete set of surface data files for CLM**
-
-A technical description on how to create new surface data sets is found here: 
-https://github.com/NorESMhub/NorESM/blob/noresm2/doc/configurations/clm_surfdata.pdf
+Surface data for default resolution (e.g., f19_tn14 for NorESM2-LM and f09_tn14 for NorESM2-MM) are available on Fram @ Sigma2: /work/shared/noresm/inputdata/lnd/clm2/surfdata_map/ 
 
 
-The inital state of CLM5
+The initial state of CLM5
 ^^^^^^
 
 The land model needs to read in the inital state from a restart file. This can be customized in user_nl_clm in the case folder ::
@@ -107,7 +103,7 @@ For example if STOP_N=50 years, you can set::
  
 -8760 means one average value per year, and 50 years in one file.
 
-- The full namelist definitions and defaults in the CLM5: http://www.cesm.ucar.edu/models/cesm2/settings/current/clm5_0_nml.html
+- The full namelist definitions and their defaults for CLM5 can be studied `here <http://www.cesm.ucar.edu/models/cesm2/settings/current/clm5_0_nml.html>`_. 
 
 Spin up of CLM5 
 ^^^^^^
@@ -176,12 +172,12 @@ NorESM2 can then be run with CLM5 using the restart file from the end of the spi
   finidat = '<path_to_inputdata>/inputdata/<path_to_file>/CLM_SPINUP_FILENAME.clm2.r.YR-01-01-00000.nc'
  
  
-A description of the NorESM2 CLM5 spin up, recoupling and diagnostics can be found here:
-https://github.com/NorESMhub/NorESM/blob/noresm2/doc/configurations/NorESM-CLM-memo.pdf
+A description of the NorESM2 CLM5 spin up, recoupling and diagnostics can be found `here <https://github.com/NorESMhub/NorESM/blob/noresm2/doc/configurations/NorESM-CLM-memo.pdf>`_. 
+
 
 Code modification 
 ^^^^^^
-To make more subtantial modification to the BLOM/iHAMOCC code than what is possible by the use of user_nl_clm, there are two methods:
+To make more subtantial modification to the CLM5 code than what is possible by the use of user_nl_clm, there are two methods:
 
 1. Make a branch from the NorESM2 version (branch or release) you want to modify, checkout this branch in order to make code changes directly in the source code folder.
 
@@ -195,8 +191,7 @@ The CLM5 source code is located in::
 Land-only experiments
 ^^^^^^
 
-**For land-only simulations**, there is no difference in running the CLM5 in CESM2 and that in NorESM2. For a detailed description on how to set up, modify, build and run CLM5 stand alone experiments, please see
-the CLM5.0 users guide: https://escomp.github.io/ctsm-docs/versions/release-clm5.0/html/users_guide/setting-up-and-running-a-case/choosing-a-compset.html (last accessed 7th May 2020)
+**For land-only simulations**, there is no difference in running the CLM5 in CESM2 and that in NorESM2. For a detailed description on how to set up, modify, build and run CLM5 stand alone experiments, please check CLM5.0's `user guide <https://escomp.github.io/ctsm-docs/versions/release-clm5.0/html/users_guide/setting-up-and-running-a-case/choosing-a-compset.html>`_  (last accessed 7th May 2020).
 
 NorESM2 specific additions
 ^^^^^^
@@ -218,8 +213,8 @@ will use CESM2 treatment of the surface water in CLM (see previous description).
 CLM5 specifics
 ^^^^^
 
-- There is no information exchange within the CLM model between sub-grid tiles (landunits, columns, plant functional types (PFTs)). 
-- Sub-grid tiles only exchange information with the atmosphere. In the current CLM, there is no advection of heat and water at depth. 
+- CLM generally treats each sub-grid element (landunits and columns) independently, without lateral exchange of energy or heat.
+- Sub-grid elements only exchange information with the atmosphere, in addition to water being removed from the grid cell as surface and subsurface runoff.
 - The horizontal resolution of the CLM keeps the same as for the atmosphere (f19, f09). 
 - Vertically, there are four soil structures to set in the CLM namelist file. CLM5 model configurations available in NorESM2:
 
@@ -238,12 +233,7 @@ By default, 20SL_8.5m is employed.
 MOSART
 -------------
 
-| The Model for Scale Adaptive River Transport (MOSART) is the default river model for CESM2, CLM5 and NorESM2. For more information please see:  
-| http://www.cesm.ucar.edu/models/cesm2/river/
-|   
-| For a techincal user guide, please see:  
-| https://escomp.github.io/ctsm-docs/versions/release-clm5.0/html/tech_note/MOSART/CLM50_Tech_Note_MOSART.html  
-
+The Model for Scale Adaptive River Transport (MOSART) is the default river model for CESM2, CLM5 and NorESM2. For more information start `here <http://www.cesm.ucar.edu/models/cesm2/river/>`_. For a techincal user guide go `here <https://escomp.github.io/ctsm-docs/versions/release-clm5.0/html/tech_note/MOSART/CLM50_Tech_Note_MOSART.html>`_.   
 
 The methods and syntax for modifying the user namelist and code in MOSART are similar to CLM5, so the previous description can be used. The user namelist for MOSART is user_nl_mosart and source code files should be copied to SourceMods/src.mosart/ in the case folder.
 

--- a/doc/configurations/experiment_environment.rst
+++ b/doc/configurations/experiment_environment.rst
@@ -1,22 +1,19 @@
 .. _experiment_environment:
 
-Experiment environments
+Experiment settings and modifications
 ===================================
 
-After creating a case (see :ref:`experiments`) the environment settings can be modified in  the env_*.xml files and the user_nl_<component> files contained in the case folder
+After creating a case (see :ref:`experiments`) and running the case.setup script the case folder is created including a number of different files and folders containing information and settings for your case. The case folder contains: 
 
-The case folder contains:
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-- **README.case:** File detailing your create_newcase usage. This is a good place for you to keep track of runtime problems and changes. The file contains information about e.g. how the case was created, compset details, grid information and which branch, git commit and model code were used for case creation.
+- **README.case:** File detailing your create_newcase usage. This is a good place for you to keep track of run-time problems and changes. The file contains information about e.g. how the case was created, compset details, grid information and which branch, git commit and model code were used for case creation.
 
 - **CaseStatus:** File containing a list of operations done in the current case.
 
 - **Buildconf:** Directory containing scripts to generate component namelists and component and utility libraries (e.g., PIO, MCT). *You should never have to edit the contents of this directory*
 
-- **SourceMods:** Directory where you can place modified source code. In SourceMods there are subfolders for the different models; cam, clm, cice, blom, mosart and so on . If you want to change the code or add subroutines, you place copies of the fortran files here. 
+- **SourceMods:** Directory where you can place modified source code. In SourceMods there are sub-folders for the different models; cam, clm, cice, blom, mosart and so on . If you want to change the code or add subroutines, you place copies of the fortran files here. 
 
-- **user made namelists:** you can place your own namelists for the different models where you can change parameters and model settings and so on (i.e. user\_nl\_cam, user\_nl\_cice, user\_nl\_clm, user\_nl\_blom, user\_nl\_cpl). See details below. 
+- **user namelists:** namelists for the different models where you can change parameters and model settings, add output variables. If you use usermods when creating your case, any pre-defined user namelists from the usermods will appear immediately when running the create_newcase script. Otherwise, empty user namelists  will be created with running the case.setup script. There is one namelist for each model component (i.e. user\_nl\_cam, user\_nl\_cice, user\_nl\_clm, user\_nl\_blom, user\_nl\_cpl). Use the user namelists to change the contents of the full namelists in the CaseDocs folder (see below). 
 
 - **CaseDocs:** here you find the namelists containing all the subroutines and parameters used. These files will be modified after rebuild. The details of parameter values and input files are listed in the <component>_in files. *You should never have to edit the contents of this directory*. If you wish to make changes to the <component>_in files, you change the user_nl_<component> and rebuild.
 
@@ -24,8 +21,162 @@ The case folder contains:
 
 - **Tools:** Directory containing support utility scripts. 
 
+In addition, the case folder contains different environment files (env_*.xml files) that contain environment settings such as the length of your run, the run type, what restart files to use, etc. Modifications to these files can be made directly using your favorite editor, or using the xmlchange script. Note not all files can be edited at any time, for instance build environment variables should not be edited after a build is invoked (or you have to re-build the model). Check the header of the xml files for guidelines.
 
-Machine specific environment
+Below we review the purpose and some of the most important settings for the environment files you will modify most often:
+
+- env_run.xml: Used to set different configuration details for the experiment such as run type and length. 
+
+- env_batch.xml: Used to set the arguments for the batch job commands.
+
+- env_mach_pes.xml: Used to set the machine-specific processor layout for the different model components
+
+We will not discuss the following files as modifications to these files are not usually required: 
+
+- env_mach_specific.xml: Used to set a number of machine-specific environment variables for building and/or running set in <noresm-base>/cime/config/cesm/machines/config_machines.xml. 
+
+- env_build.xml: Used to set various variables needed when building the model. Should not be modified once the model has been build. 
+  
+- env_case.xml: Used to set case-specific variables (e.g. model components, model and case root directories) and *cannot be modified after a case has been created.* To make changes, your need to re-run ./create_newcase.sh in <noresm-base>/cime/scripts/  with different options. 
+
+- env_archive.xml: Sets variables needed for the short-term archiving job.
+
+
+
+
+
+
+Run environment
+^^^^^^^^^^^^^^^^
+The file
+
+::
+  
+  env_run.xml
+  
+::
+
+sets the configuration details for the experiment such as the run type, the length of the run, how often restart files should be produced, output of coupler diagnostics, and short-term and long-term restart file archiving.
+
+
+
+
+Some common configuration settings
+----------------------------------
+
+- RUN_TYPE:
+
+  - **startup:** In a startup run (the default), all components are initialized using baseline states. These baseline states are set independently by each component and can include the use of restart files, initial files, external observed data files, or internal initialization (i.e., a cold start). If you want to initialize the model using non-default files, you can do this in the user_nl_<component> files.
+  
+  - **branch:** In a branch run, all components are initialized using a consistent set of restart files from a previous run (determined by the RUN_REFCASE and RUN_REFDATE variables in env\_run.xml).  The case name is generally changed for a branch run, although it does not have to be. In a branch run, setting RUN_STARTDATE is ignored because the model components obtain the start date from their restart data sets. Therefore, the start date cannot be changed for a branch run. RUN_REFCASE and RUN_REFDATE are required for branch runs. To set up a branch run, locate the restart tar file or restart directory for RUN_REFCASE and RUN_REFDATE from a previous run, then place those files in the RUNDIR directory.
+  
+  - **hybrid:** Not as strict as branch. In a hybrid run the model is initialized as a startup, BUT uses initialization data sets from a previous case. This is somewhat analogous to a branch run with relaxed restart constraints.  A hybrid run allows users to bring together combinations of initial/restart files from a previous case (specified by RUN\_REFCASE) at a given model output date (specified by RUN\_REFDATE). Unlike a branch run, the starting date of a hybrid run (specified by RUN\_STARTDATE) can be modified relative to the reference case.
+ 
+- RUN_REFCASE:
+
+  - Reference data used for hybrid or branch runs. The name of the reference simulation the model components are initialized from. The restart and rpointer files should be copied to the run directory before the job is submitted. 
+ 
+- RUN_REFDATE:
+
+  - The reference date for branch or hybrid runs. The reference date must match the date of the restart files from the simulation set in RUN_REFCASE
+  
+- RUN_STARTDATE:
+
+  - Set the date (of your own wish) for the beginning of the simulation. Only used for hybrid runs.
+  
+- STOP_OPTION: 
+
+  - Sets the run length along with STOP_N. Can choose between e.g.: none, never, nstep, nhours, ndays, nday, nmonths, nyears, date.
+  
+- STOP_N:
+
+  - Provides a numerical count for $STOP_OPTION. E.g. if STOP_OPTION is set to years and STOP_N set to 20, the model will run for 20 years.
+  
+- REST_OPTION:
+
+  - Sets the frequency of model restart files output (same options as STOP_OPTION)
+  
+- REST_N:
+  
+  - Provides a numerical count for $REST_OPTION. E.g. if REST_OPTION is set to years and STOP_N set to 5, the model will produce restart files every 5 years.
+  
+- CONTINUE_RUN:
+   
+  - Needs to be FALSE when you first begin the run. When you successfully run and get restart files (if the model crashes after the restart files are produced you can set CONTINUE_RUN to TRUE as well), you will need to change CONTINUE_RUN to TRUE for the remainder of your simulation. 
+      
+- RESUBMIT:
+
+  - If RESUBMIT is greater than 0, then case will automatically resubmit. Enables the model to automatically resubmit a new run. This is very useful for long simulations. E.g. RESUBMIT is set to 2 and the simulation length is set to 20 years (STOP_OPTION is years and STOP_N is 20), the total length of the simulation will be 60 years.
+   
+- RESUBMIT_SETS_CONTINUE_RUN:
+ 
+  - Needs to be TRUE (default) for the RESUBMIT flag to causes a resubmisson of the case
+   
+- DOUT_S_SAVE_INTERIM_RESTART_FILES:
+ 
+  - Set to TRUE to archive all restart files that are produced or to FALSE to only archive restart files that are produced at the end of the run. Default is TRUE.
+
+
+
+
+NorESM2-specific configuration settings
+---------------------------------------
+- FLUXSCHEME=1 
+
+  - In the coupled NorESM2 simulations, the flux parameterization used for the transfer of heat, moisture and momentum between the ocean and atmosphere is the so-called COARE flux parameterization. This choice is activated by FLUXSCHEME=1 in env_run.xml, and ends up in the driver_in namelist as fluxscheme=1. This parameterization is different from the standard flux-parameterization used in CESM, which is activated by FLUXSCHEME=0.
+ 
+- ALBCOSZAVG=.true. 
+
+  - a feature of the coupled NorESM2 simulations, i.e., taking into account the fact that the solar zenith angle used for the calculation of the surface albedo changes over the atmospheric model time step of 30 minutes 
+
+
+
+    
+Setting up a hybrid simulation
+-----------
+Step by step guide for setting up an  hybrid (restart) simulation.
+
+When the case is created and compiled, edit ``env_run.xml``. Below is an example for restart with CMIP6 historical initial conditions::
+
+
+
+    <entry id="RUN_TYPE" value="hybrid">
+    <entry id="RUN_REFDIR" value="<full-path-to-restart-file-directory>">                  # path to restarts
+    <entry id="RUN_REFCASE" value="NHISTfrc2_f09_tn14_20191025">     # experiment name for restart files
+    <entry id="RUN_REFDATE" value="2015-01-01">                      # date of restart files
+    <entry id="RUN_STARTDATE" value="2015-01-01">                    # date in simulation
+    <entry id="GET_REFCASE" value="TRUE">                            # get refcase from outside rundir
+
+If it is not possible to link directly to restarts, copy the restart files and rpointer files to the run directory. In this case it is not necessary to set RUN_REFDIR and GET_REFCASE can be set to FALSE, e.g.::
+
+    <entry id="RUN_TYPE" value="hybrid">
+    <entry id="RUN_REFCASE" value="NHISTfrc2_f09_tn14_20191025">     # Experiment name for restart files
+    <entry id="RUN_REFDATE" value="2015-01-01">                      # date of restart files
+    <entry id="RUN_STARTDATE" value="2015-01-01">                    # date in simulation
+    <entry id="GET_REFCASE" value="FALSE">                           # get refcase from outside rundir
+
+
+
+Batch job environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The file
+
+::
+  
+  env_batch.xml
+  
+::
+
+
+sets the arguments to the batch job commands. There are two jobs; one for running the model (case.run) and one for moving the files from the RUNDIR to the archive directory (case.st_archive). The archiving is usually very fast (less than one hour), but for very large jobs (high resolution or large output) it can take several hours. 
+
+Some of the most commonly modified configuration settings are those related to the walltime for the two jobs.
+
+
+
+
+
+Machine-specific environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The file
@@ -36,7 +187,7 @@ The file
   
 ::
 
-sets component machine-specific processor layout. The settings are critical to a well-load-balanced simulation. Here you set the number of cpus used for each model component and the coupler (usually land + ice + rof (river run off) = atm = coupler). An example of sunch an env_mach_pes.xml file:
+sets the component machine-specific processor layout. The settings are critical to a well-load-balanced simulation. Here you set the number of cpus or tasks (NTASKS) used for each model component and the coupler (usually land + ice + rof (river run off) = atm = coupler). An example of the NTASKS-settings from an env_mach_pes.xml file could be:
 
 ::
   
@@ -59,121 +210,27 @@ sets component machine-specific processor layout. The settings are critical to a
 
 ::
 
+Note that positive values are used for setting the number of tasks whereas negative values can be used to set the number of cpus instead.
 
-Run environment
-^^^^^^^^^^^^^^^^
-The file
+The env_mach_pes.xml file will usually be created with default values based on the machine you specify (with the --mach option) when you create the case with the create_newcase script.
 
-::
-  
-  env_run.xml
-  
-::
-
-sets the configuration details for the experiment. E.g. time settings such as length of run, frequency of restart files produced, output of coupler diagnostics, and short-term and long-term restart file archiving. 
-
-NorESM2 specific configuration settings
----------------------------------------
-- FLUXSCHEME=1 
-
-  - In the coupled NorESM2 simulations, the flux parameterization used for the transfer of heat, moisture and momen-tum between the ocean and atmosphere is the so-called COARE flux parameterization. This choice is activated by FLUXSCHEME=1 in envrun.xml, and ends up in the driver_in namelist as fluxscheme=1. This parameterisationis different from the standard flux-parameterzation used in CESM, which is activated by FLUXSCHEME=0.
- 
-- ALBCOSZAVG=.true. 
-
-  - a feature of the coupled NorESM2 simulations, i.e., taking into account the fact that the solar zenith angle used for the calculation of the surface albedo changes over the atmospheric model time step of 30 minutes 
-
-Some common configuration settings
-----------------------------------
-
-- RUN_TYPE:
-
-  - **startup:** In a startup run (the default), all components are initialized using baseline states. These baseline states are set independently by each component and can include the use of restart files, initial files, external observed data files, or internal initialization (i.e., a cold start). Settings of initial files to be read are set in the user_nl_<component>
-  
-  - **branch:** In a branch run, all components are initialized using a consistent set of restart files from a previous run (determined by the RUN_REFCASE and RUN_REFDATE variables in env\_run.xml).  The case name is generally changed for a branch run, although it does not have to be. In a branch run, setting RUN_STARTDATE is ignored because the model components obtain the start date from their restart datasets. Therefore, the start date cannot be changed for a branch run. RUN_REFCASE and RUN_REFDATE are required for branch runs. To set up a branch run, locate the restart tar file or restart directory for RUN_REFCASE and RUN_REFDATE from a previous run, then place those files in the RUNDIR directory.
-  
-  - **hybrid:** Not as strict as branch. In a hybrid run the model is initialized as a startup, BUT uses initialization datasets from a previous case. This is somewhat analogous to a branch run with relaxed restart constraints.  A hybrid run allows users to bring together combinations of initial/restart files from a previous case (specified by RUN\_REFCASE) at a given model output date (specified by RUN\_REFDATE). Unlike a branch run, the starting date of a hybrid run (specified by RUN\_STARTDATE) can be modified relative to the reference case.
- 
-- RUN_REFCASE:
-
-  - Reference data used for hybrid or branch runs. The name of the reference simulation the model components are initialized from. The restart and rpointer files should be copied to the run directory before the job is submitted 
- 
-- RUN_REFDATE:
-
-  - The reference date of the restart files from the simulation set in RUN_REFCASE
-  
-- RUN_STARTDATE:
-
-  - Set the date (of your own wish) for the beginning of the simulation
-  
-- STOP_OPTION: 
-
-  - Sets the run length along with STOP_N. Can choose between e.g.: none, never, nstep, nhours, ndays,nday,nmonths ,nyears, date.
-  
-- STOP_N:
-
-  - Provides a numerical count for $STOP_OPTION. E.g. if STOP_OPTION is set to years and STOP_N set to 20, the model will run for 20 years.
-  
-- REST_OPTION:
-
-  - Sets the frequency of model restart files output (same options as STOP_OPTION)
-  
-- REST_N:
-  
-  - Provides a numerical count for $REST_OPTION. E.g. if REST_OPTION is set to years and STOP_N set to 5, the model will produce restart files every 5 years.
-  
-- CONTINUE_RUN:
-   
-  - Needs to be FALSE when you first begin the run. When you successfully run and get a restart file (if the model crashes after the restart file is produced you can set CONTINUE_RUN to TRUE as well), you will need to change CONTINUE_RUN to TRUE for the remainder of your simulation. 
-      
-- RESUBMIT:
-
-  - If RESUBMIT is greater than 0, then case will automatically resubmit. Enables the model to automatically resubmit a new run. This is very useful for long simulations. E.g. RESUBMIT is set to 2 and the simulation length is set to 20 years (STOP_OPTION is years and STOP_N is 20), the total length of the simulation will be 60 years.
-   
-- RESUBMIT_SETS_CONTINUE_RUN:
- 
-  - Needs to be TRUE (default) is the RESUBMIT flag causes a resubmisson of the case
-   
-- DOUT_S_SAVE_INTERIM_RESTART_FILES:
- 
-  - Logical to archive all the produced restart files and not just those at the end of the simulation. Default is FALSE.
-  
-Setting up a hybrid simulation
-^^^^^
-Step by step guide for hybrid simulation/restart.
-
-When the case is created and compiled, edit ``env_run.xml``. Below is an example for restart with CMIP6 historical initial conditions::
+For more information, see description in the header for the env_mach_pex.xml file.
 
 
 
-    <entry id="RUN_TYPE" value="hybrid">
-    <entry id="RUN_REFDIR" value="path/to/restars">                  # path to restarts
-    <entry id="RUN_REFCASE" value="NHISTfrc2_f09_tn14_20191025">     # experiment name for restart files
-    <entry id="RUN_REFDATE" value="2015-01-01">                      # date of restart files
-    <entry id="RUN_STARTDATE" value="2015-01-01">                    # date in simulation
-    <entry id="GET_REFCASE" value="TRUE">                            # get refcase from outside rundir
 
-If it is not possible to link directly to restarts, copy the restart files and rpointer files to the run directory. Below is example changes to ``env_run.xml``::
-
-
-    <entry id="RUN_TYPE" value="hybrid">
-    <entry id="RUN_REFCASE" value="NHISTfrc2_f09_tn14_20191025">     # Experiment name for restart files
-    <entry id="RUN_REFDATE" value="2015-01-01">                      # date of restart files
-    <entry id="RUN_STARTDATE" value="2015-01-01">                    # date in simulation
-    <entry id="GET_REFCASE" value="FALSE">                           # get refcase from outside rundir
 
 
 User namelists
 ^^^^^^^^^^^^^^
 
 
-Frequency of output
+Output frequency
 -------------------
 
-There are plenty of default output variables which are automatically written,
+In NorESM a number of monthly output variables are automatically written to the output/history files (see :ref:`standard_output`). Output variables and/or output frequencies (daily, 6-hourly, etc) that are not outputted by default can be added using the user namelists.
 
-The variables specified in the namelists will be written as output automatically, but if you need to customize the output fields you can eddit the user_nl_<component> lists
-
-E.g. if you eddit user_nl_cam and add the following lines at the end of the file::
+For instance, if you edit user_nl_cam and add the following lines at the end of the file::
 
             avgflag_pertape = ’A’,’I’
             nhtfrq = 0 ,-6
@@ -186,19 +243,19 @@ E.g. if you eddit user_nl_cam and add the following lines at the end of the file
 
 - avgflag_pertape
 
-  Sets the averaging flag for all variables on a particular history file series. Default is to use default averaging flags for each variable. Average (A), Instantaneous (I), Maximum (X), and Minimum (M). 
+  Sets the averaging flag for all variables in a particular history file series. Options are: Average (A), Instantaneous (I), Maximum (X), and Minimum (M). The default behavior is the use the same averaging flag for all variables in each particular history file series, but this can be overridden (more information below). 
   
 - nhtfrq
 
   Array of write frequencies for each history files series.
   
   - nhtfrq = 0, the file will be a monthly average. Only the first file series may be a monthly average. 
-  - nhtfrq > 0, frequency is input as number of timesteps.
+  - nhtfrq > 0, frequency is input as number of time steps.
   - nhtfrq < 0, frequency is input as number of hours.
 
 - mfilt
 
-  Array of number of time samples to write to each history file series (a time sample is the history output from a given timestep)
+  Array of number of time samples to write to each history file series (a time sample is the history output from a given time step)
   
 - nden
 
@@ -206,7 +263,7 @@ E.g. if you eddit user_nl_cam and add the following lines at the end of the file
    
 - fincl1
 
-  List of fields to add to the primary history file. 
+  List of fields to add to the primary history file. Note in the above example the default averaging behavior for the file is overridden for some variables by adding a ":" followed by an averaging option.
  
 - fincl2
 
@@ -218,7 +275,7 @@ For a detailed description of NorESM2 output, please see :ref:`output`
 
 Parameter settings
 ------------------
-If you need to change some variable values or activate/deactive flags, that can also be done in user_nl_<component>. The syntax is::
+If you need to change some variable values or activate/deactivate flags, that can also be done in user_nl_<component>. The syntax is::
 
   &namelist_group
     namelist_var = new_namelist_value
@@ -232,22 +289,22 @@ E.g for a quadrupling of the atmospheric CO2 concentration
 
 ::
 
-Note that BLOM uses a different sytax than the rest. In user_nl_blom::
+Note that BLOM uses a different syntax than the rest. In user_nl_blom::
 
-  set BDMC2    = .15
+  set BDMC2 = .15
   set NIWGF = .5
 
-you need to include **set** before the name of the variable and it does not matter what namelist group the valiable belong.
+you need to include **set** before the name of the variable and it does not matter what namelist group the variable belong.
 
 
 Input data
 -----------
-All active and data components use input data sets. A local disk needs DIN_LOC_ROOT to be populated with input data in order to run NorESM. You can make links to the input data sets in the user_nl_<components>. 
+All active model components and data components use input data sets. Wherever you are running the model, you need to store the input locally under DIN_LOC_ROOT in order to run NorESM. If you want to use non-default input data, you can set the path to the file you want to use in the relevant user_nl_<components>. 
 Input data is handled by the build process as follows:
 
-- The buildnml scripts in Buildconf/ create listings of required component input datasets in the Buildconf/<component>.input_data_list files
+- The buildnml scripts in Buildconf/ create listings of required component input data sets in the Buildconf/<component>.input_data_list files
   
-- ./case.build checks for the presence of the required input data files in the root directory DIN_LOC_ROOT. If all required data sets are found on local disk, then the build can proceed.
+- The case.build scripts checks for the presence of the required input data files in the root directory DIN_LOC_ROOT. If all required data sets are found on local disk, then the build can proceed.
   
 - If any of the required input data sets are not found, the build script will abort and the files that are missing will be listed. At this point, you must obtain the required data from the input data server using check_input_data with the -export option. 
 
@@ -255,7 +312,7 @@ Input data is handled by the build process as follows:
 Aerosol diagnostics
 ^^^^^^^^^^
 
-The model can be set up to take out AeroCom-specific output, effective forcing estimates, and other additional aerosol output. See :ref:`aerosol_output` for details. 
+The model can be set up to output AeroCom-specific variables, effective forcing estimates, and other additional aerosol output. See :ref:`aerosol_output` for details. 
 
 COSP
 ^^^^^^^
@@ -264,28 +321,11 @@ NorESM2 can be run with the CFMIP Observation Simulator Package (COSP) to calcul
 
 Code modifications
 ^^^^^^^^^^^^^^^^^^^
-If you want to make more subtantial changes to the codes than what is possible by the use of user_nl_<component>, you need to copy the source code (the fortran file you want to modify) to the SourceMods/src.<component> folder in the case directory, then make the modifications needed before building the model. Make sure that you use the source code from the same commit as you used to create the case (for commit details see README.case in the case folder). **Do not change the source code in the <noresm-base> folder!**  
+Sometimes you will want to make changes that go beyond what is possible from just changing the user namelists, and you will need to modify the source code itself (i.e. the fortran files). One way of doing this is to use the SourceMods folder in the case directory. The SourceMods folder contains sub-directories for all model component. Make a copy of the fortran file(s) you want to modify in the relevant sub-folder and modify the file(s) as needed before building the model. When compiling, the model will prioritize the modified file located under the SourceMods folder over the default version of the file located in the model source code under <noresm-base>.
 
+Another option is to make a new branch for your code modifications following the procedure outlined in :ref:`gitbestpractice`. This has several advantages to using SourceMods, including that your changes are more easily visible for others (in your NorESM fork on GitHub), making them easy to share, and that the changes can more easily be considered for inclusion in the main NorESM repository on GitHub. 
 
-Run and archiving time environment
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The file
+In either case, make sure that you use the source code from the same commit as you used to create the case (for commit details see README.case in the case folder).
 
-::
-  
-  env_batch.xml
-  
-::
-
-
-sets the batch file or job script configurations. You need to specify two jobs; one for running the model (case.run) and one for moving the files from the RUNDIR to the archive directory (case.st_archive). The archiving is usually very fast (less than one hour), but for very large jobs (high resolution or large output) it can take several hours. 
-
-You can edit the xml files directly to change the variable values. Although you can edit this at any time, build environment variables should not be edited after a build is invoked. 
-
-There are also other env_ files which you usually don't need to or can't change:
-
-- env_mach_specific.xml: File used to set a number of machine-specific environment variables for building and/or running set in <noresm-base>/cime/config/cesm/machines/config_machines.xml. 
-
--  env_case.xml: Sets case specific variables (e.g. model components, model and case root directories) and *cannot be modified after a case has been created.* To make changes, your need to re-run ./create_newcase.sh in <noresm-base>/cime/scripts/  with different options. 
 
 

--- a/doc/configurations/experiments.rst
+++ b/doc/configurations/experiments.rst
@@ -3,7 +3,7 @@
 Experiments
 ===========
 
-NorESM is part of the CESM family of earth system models and shares a lot of the configuration options with CESM. Many of the simulation configuration settings are defined by the so called compsets.
+NorESM is part of the CESM family of earth system models and shares a lot of the configuration options with CESM. Many of the simulation configuration settings are defined by the so-called compsets.
 
 For a quick-start guide on how to create, configure, build, and submit a NorESM experiment, see the :ref:`newbie-guide`. More details are provided below, for the more advanced users. 
 
@@ -19,49 +19,16 @@ script, a case folder ``<path_to_case_dir>/<casename>`` is created that contains
 
   ./case.setup
 
-script, several other files and directories needed to build the case are created, including the user user namelists files.
+script, several other files and directories needed to build the case are created, including the user namelists files. 
+
+The case folder contains predefined namelists (with namelist settings partly depending on compset option). The default namelist options for the case can be overwritten by changing/adding the new namelist options in the ``user_nl_<component>`` file.
+
 
 The create_newcase script includes a ``--compset`` option. A compset, or component set, is a collection of predefined setting that defines your experiment set-up, including which model components that should be activated. Some of the available compsets are described below.
 
-The case folder contains predefined namelist (with namelist settings partly depending on compset option). The default namelist options for the case can be overwritten by changing/adding the new namelist options in the ``user_nl_<component>`` file.
-
-Several configuration options are available in the usermods directories in ``<noresm_base>/cime_config/usermods_dirs/``. These folders contain information about output variables and frequencies from clm (land) and cam (atmosphere). In addition one SourceMod is included in ``SourceMods/src.cam/preprocessorDefinitions.h`` to define if AEROFFL and AEROCOM are included for extra aerosol diagnostics (for more details about the aerosol diagnostics see ``??``)
-
-Remember that the amount of diagnostics and the output frequency have a huge impact on both the run time and storage. 
-
-``--user-mods-dir cmip6_noresm_*`` ::
-
-  cmip6_noresm_DECK (AEROFFL)    
-  cmip6_noresm_hifreq (high frequency output, AEROFFL)    
-  cmip6_noresm_hifreq_xaer (high frecuency output, AEROFFL and AEROCOM)   
-  cmip6_noresm_xaer (AEROFFLand AEROCOM)    
-
-For more details about the user-mod-dir options, check this folder ::
-
-<noresm_base>/cime_config/usermods_dirs
-
-
-The xmlchange and xmlquery scripts
-^^^^^^^^^^^
-
-The ``xmlchange`` and ``xmlquery`` scripts are located in your case folder and lets you change or query the contents of variables in the ``evn_*.xml`` files without entering the files. There are two advantages of using ``xmlchange`` to edit the xml files rather than doing by hand: (1) the ``xmlchange`` script checks that the new setting is valid and (2) the change is echoed to the ``CaseStatus`` file, thus automatically documented. To change from the default ``ndays`` to ``nmonths`` ::
-
-  ./xmlchange STOP_OPTION=nmonths
-  
-It's also possible to change several variables at once, for instance ::
-
-  ./xmlchange STOP_OPTION=nmonths,STOP_N=14
-
-See the header of ``xmlchange`` and ``xmlquery`` for more details and examples.
-
-
-Create a clone case
-^^^^^^^^^^^^^^^^^^^
-To create clone cases from a control case can be very useful for e.g. sensitivity studies. If you want to make a copy of a case (i.e. identical ``./create_newcase`` command and identical ``env_*.xml``, ``user_nml_<component>`` and ``SourceMods`` files) that can be done by the use of ``./create_clone``. You only need to give the casename of the new case and the casename of the case which sholud be cloned (copied). The case will have identical set up (``env_*.xml``, ``user_nml_<component>`` files and ``SourceMods``) as the clone, but these files can of course be modified before building the case.
-
 
 Compsets
-^^^^^^^^
+'''''''''''''
 
 Compsets, or component sets, specify which component models will be used in your simulation along with which forcing files, and even which physics options to use. Each compset has a long name (lname) and an alias. For instance ``N1850`` is the alias for the NorESM compset for pre-industrial (1850) conditions. The long name for ``N1850`` is ::
   
@@ -71,78 +38,47 @@ The long name generally follows the notation ::
 
   TIME_ATM[%phys]_LND[%phys]_ICE[%phys]_OCN[%phys]_ROF[%phys]_GLC[%phys]_WAV[%phys][_ESP%phys][_BGC%phys] 
 
-(see the help section of the file ``<noresm_base>/cime_config/config_compsets.xml`` for details). The compsets can also include information on which grids are scientifcally supported (see below for details). 
+(see the help section of the file ``<noresm_base>/cime_config/config_compsets.xml`` for details). The compsets can also include information on which grids are scientifically supported (see below for details). 
 
-All predefined compsets for **coupled simulations** can be found in ::
+To find all predefined compsets:
 
-  <noresm_base>/cime_config/config_compsets.xml
-
-Predefined compsets for **AMIP-type (atmsophere/land-only) simulations** can be found in ::  
-
-  <noresm_base>/components/cam/cime_config/config_compsets.xml
+* **coupled simulations** ``<noresm_base>/cime_config/config_compsets.xml``
+* **AMIP-type (atmsophere/land-only) simulations** ``<noresm_base>/components/cam/cime_config/config_compsets.xml``
+* stand-alone experiments with the sea-ice model  ``<noresm_base>/components/cice/cime_config/config_compsets.xml``
+* stand-along experiments with the land model ``<noresm_base>/components/clm/cime_config/config_compsets.xml``
+* Stand-alone experiments with the ocean model  ``<noresm_base>/components/blom/cime_config/config_compsets.xml``
   
-Predefined compsets for running the sea-ice model as a stand-alone model cam be found in ::
+The compsets starting with N are NorESM coupled configurations. Compsets starting with NF are NorESM AMIP (atmosphere/land-only) configurations. Some examples are:
 
-  <noresm_base>/components/cice/cime_config/config_compsets.xml
-
-Predefined compsets for running the land model as a stand-alone model can be found in ::
-
-  <noresm_base>/components/clm/cime_config/config_compsets.xml
-  
-Predefined compsets for running the ocean model as a stand-alone model can be found in ::
-
-  <noresm_base>/components/blom/cime_config/config_compsets.xml
-  
-The compsets starting with N are NorESM coupled configurations. Compsets starting with NF are NorESM AMIP (atmosphere only) configurations. Some examples are given below.
-
-**N1850 and N1850frc2**  
-  Coupled configuration for NorESM for pre-industrial (1850) conditions.
-
-**NHIST and NHISTfrc2**
-  Historical configuration from 1850 up to year 2015 (see detailed description below; 'Create your own compsets for AMIP simulations')
-
-**NSSP126frc2, NSSP245frc2, NSSP370frc2, NSSP585frc2**  
-  Future scenario compsets from 2015 to 2100
-  
-**NFHISTnorpddmsbc**  
-  AMIP simulation with time-evolving prescribed observed values for SSTs and sea ice and upper-ocean DMS values derived from a fully coupled NorESM2 simulation for present-day conditions
-  
-**frc2 emission files**
-  The frc2 option uses differently organized emission files. The frc2 files are located in ::
+* **N1850 and N1850frc2**: Coupled configuration for NorESM for pre-industrial (1850) conditions.
+* **NHIST and NHISTfrc2**: Historical configuration from 1850 up to year 2015 (see detailed description below; 'Create your own compsets for AMIP simulations')
+* **NSSP126frc2, NSSP245frc2, NSSP370frc2, NSSP585frc2**: Future scenario compsets from 2015 to 2100
+* **NFHISTnorpddmsbc**: AMIP simulation with time-evolving prescribed observed values for SSTs and sea ice and upper-ocean DMS values derived from a fully coupled NorESM2 simulation for present-day conditions
+ 
+**frc2 compsets**: The frc2 option uses differently organized emission files. The frc2 files are located in ::
   
   <PATH_TO_INPUTDATA>/noresm/inputdata/atm/cam/chem/emis/cmip6_emissions_version20190808
   
-A new set of emission files have been made to avoid the occurence of random mid-month model crashes. These crashes are related to the reading of emission files, but are still under investigation. To use the newest emission files choose compsets including *frc2* or if you  want to create a new compset add ::
+The frc2 files were created to avoid the occurence of random mid-month model crashes. These crashes are related to the reading of emission files, but are still under investigation. To make sure that you are using the frc2 files, choose a compsets including *frc2* or if you  want to create a new compset add ::
 
   %FRC2
  
-to NORESM2. For a detailed description, see **Creating your own compset** below.
+to NORESM2. For a detailed description, see the section on creating your own compset below.
 
 For an overview of the compsets provided for CESM2, please see: http://www.cesm.ucar.edu/models/cesm2/config/compsets.html.
 
 
-**Supported grids**
-
-Most compsets contain an entries listing which which grid(s) are scientifically supported for that compset ::
-
-<science_support grid="xxx"/> fields
-
-When a compset has a scientifically-supported grid, you can create a new case (with the create_newcase script) without having to use the option ``--run-unsupported``. If the compset does not list any scientifically-supported grids, or if you want to use a grid configuration is not included in the definition of the compset, the ::
-
-  --run-unsupported
-
-option is required when a case is created or the create_newcase script will fail.
-
-
 Creating your own compset
-^^^^^^^^^^^^^^^^^^^^^^^^^
-The essential file to edit for a new coupled NorESM compset is :: 
+'''''''''''''''''''''''''
+The essential file to edit for a new coupled NorESM compset is
+::
 
-  <noresm_base>/cime_config/config_compsets.xml
+    <noresm_base>/cime_config/config_compsets.xml
   
-and for a new AMIP NorESM compset is :: 
+and for a new AMIP NorESM compset is
+::
 
-  <noresm_base>/components/cam/cime_config/config_compsets.xml
+    <noresm_base>/components/cam/cime_config/config_compsets.xml
   
   
 **Coupled simulation** 
@@ -156,22 +92,11 @@ This examples shows how to simply add the "N1850frc2" compset to ``config_compse
  
 where 
 
-``<alias>COMPSETNAME</alias>``
-sets the compsets name used when building a new case. Make sure to use a new and unique compset name. The details of the compset i.e. which models components and component-specific configurations to use are set in ::
+* ``<alias>COMPSETNAME</alias>`` sets the compsets name used when building a new case, make sure to use a new and unique name
+* '_' is used as a separator between model components: ``_<MODEL>``
+* '%' is used to to set components-specific configurations 
 
-<lname>1850_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-
-It is also possible to just add that line (without the <lname>) when creating a new case. 
-
-'_' seperates between model components ::
-
-_<MODEL>
-  
-and '%' sets the component-specific configuration ::
-
-%MODEL_CONFIGURATION
-
-E.g. 
+So for the N1850frc2 compset, the different parts of the lname have the following meaning:
 
 - 1850_CAM60%NORESM%FRC2
    - Forcing and input files read from pre-industrial conditions (1850). If you need a historical run replace 1850 with HIST
@@ -189,10 +114,128 @@ E.g.
 - BGC%BDRDDMS
    - ocean biogeochemistry model iHAMOCC run with interactive DMS
 
+The details of the compset i.e. which models components and component-specific configurations to use are set in
+::
+    <lname>1850_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+
+It is possible to use the long name (lname) to select a compset then creating a new case.  
+
 
 **AMIP simulation**
 
 For details about AMIP simulation compsets, please see :ref:`amips`
+
+
+
+Resolution and grids
+''''''''''''
+
+The model resolution is set when the case is created (with the ``--res`` option). Below some common resolutions are listed. 
+
+**Atmospheric grids**
+::
+
+  f19_f19 - atm lnd 1.9x2.5
+  f09_f09 - atm lnd 0.9x1.25  
+  f09_f09_mg17
+
+
+**Ocean grids**
+::
+
+  tnx1v4   - tripolar ocn ice 1-degree grid  
+  tnx2v1   - tripolar ocn ice 2-degree grid  
+  tx0.25v4 - tripolar ocn ice 1/4-degree grid  
+
+
+**Coupled**
+::
+
+  f19_tn14   - atm lnd 1.9x2.5, ocnice tnx1v4  [CMIP6 grid, NorESM2-LM]  
+  f09_tn14   - atm lnd 0.9x1.25, ocnice tnx1v4  [CMIP6 grid, NorESM2-MM]  
+  f09_tn0254 - atm lnd 0.9x1.25, ocnice tnx0.25v4  
+
+
+A complete list of model grids can be found here::
+  
+  <noresm_base>/cime/config/cesm/config_grids.xml
+
+
+Supported grids
+'''''''''''''
+
+Most compsets contain an entries listing which which grid(s) are scientifically supported for that compset
+::
+
+    <science_support grid="xxx"/> fields
+
+When a compset has a scientifically-supported grid, you can create a new case (with the **create_newcase** script) without having to use the option ``--run-unsupported``. If the compset does not list any scientifically-supported grids, or if you want to use a grid configuration is not included in the definition of the compset, the ::
+
+  --run-unsupported
+
+option is required when a case is created or the **create_newcase** script will fail.
+
+
+User modifications (usermods) 
+'''''''''''''''''''''''''''''
+Several configuration options are available in the user modification (usermod) directories under ``<noresm_base>/cime_config/usermods_dirs/``. The sets of usermods contain pre-defined user namelists for the atmosphere (cam) and land (clm) components that have been used for specific experiments, such as the CMIP6 DECK experiments. Within the user namelists, the lists of output variables and output frequencies has been modified and/or extended with additional output variables. In addition, the usermodes include one SourceMod (``SourceMods/src.cam/preprocessorDefinitions.h``) which  defines whether AEROFFL and AEROCOM are activated to produce extra aerosol diagnostics (for more details about the aerosol diagnostics see :ref:`aerosol_output`)
+
+The usermods under ``<noresm_base>/cime_config/usermods_dirs/`` include::
+
+  cmip6_noresm_DECK (AEROFFL)    
+  cmip6_noresm_hifreq (high frequency output, AEROFFL)    
+  cmip6_noresm_hifreq_xaer (high frecuency output, AEROFFL and AEROCOM)   
+  cmip6_noresm_keyCLIM (used for KeyCLIM experiments, AEROFFL)
+  cmip6_noresm_xaer (AEROFFLand AEROCOM)    
+  
+To activate the cmip6_noresm_DECK usermod, run the create_newcase script with the option ``--user-mods-dir cmip6_noresm_DECK``. 
+
+Remember that the amount of diagnostics and the output frequency have a huge impact on both the run time and storage. 
+
+For more details, check this folder ::
+
+  <noresm_base>/cime_config/usermods_dirs
+
+
+Create a clone case
+''''''''''''''''
+The create_clone script in the <noresm_base>/cime/scripts folder allows you to create a clone of an already existing case::
+
+  ./create_clone --clone <full-path-to-experiment-to-be-cloned> --case <full-path-to-cloned-experiment>
+
+Creating a clone case can be very useful if you want to recreate an existing case or if you want to create a perturbed version. The clone will be set up as if it was created with the same create_newcase options as the existing case (except the case name) and will have identical ``env_*.xml``, ``user_nml_<component>`` and ``SourceMods`` files (these files can of course be modified before building the case). 
+
+
+
+The xmlchange and xmlquery scripts
+''''''''''''''''''
+
+The ``xmlchange`` and ``xmlquery`` scripts are located in your case folder and lets you change or query the contents of variables in the ``evn_*.xml`` files without entering the files. There are two advantages of using ``xmlchange`` to edit the xml files rather than doing by hand: (1) the ``xmlchange`` script checks that the new setting is valid and (2) the change is echoed to the ``CaseStatus`` file, thus automatically documented. To change from the default ``ndays`` to ``nmonths`` ::
+
+  ./xmlchange STOP_OPTION=nmonths
+  
+It's also possible to change several variables at once, for instance ::
+
+  ./xmlchange STOP_OPTION=nmonths,STOP_N=14
+
+See the header of ``xmlchange`` and ``xmlquery`` for more details and examples.
+
+
+Forcing
+''''''''''''''''
+Please see :ref:`input`
+
+Choosing output
+'''''''''''''''
+please see :ref:`output`
+
+Setting up a nudged simulation
+''''''''''''''''''''''''''''''
+please see :ref:`nudged_simulations`
+
+
+
+
 
 
 Building the case
@@ -209,12 +252,12 @@ If you want to ensure your case is ready for submission, you can run ::
   
 which will:
 
-- Ensure that all of the env xml files are in sync with the locked files
+- Ensure that all of the ``env_*.xml`` files are in sync with the locked files
 - Create namelists (thus verifying that there will be no problems with namelist generation)
 - Ensure that the build is complete
 
 Running this is completely optional: these checks will be done
-automatically when running case.submit. However, you can run this if you
+automatically when running **case.submit**. However, you can run this if you
 want to perform these checks without actually submitting the case.
 
 As a last step, remember to copy restart files to run directory if you are running a branch run or a hybrid run.
@@ -225,54 +268,3 @@ Submitting the case
 The case is submitted by ::
 
   ./case.submit
-
-
-Resolution
-''''''''''
-
-Model resolution is set when the case is created. Below some common resolutions are listed. A complete list of model grids can be found here:
-::
-  
-  <noresm_base>/cime/config/cesm/config_grids.xml
-
-
-Atmospheric grids
-^^^^^^^^^^^^^^^^^
-::
-
-  f19_f19 - atm lnd 1.9x2.5
-  f09_f09 - atm lnd 0.9x1.25  
-  f09_f09_mg17
-
-
-Ocean grids
-^^^^^^^^^^^
-Currently, BLOM supports three resolutions, nominal 2,1, and 1/4 degrees in a tripolar grid configuration:
-::
-
-  tnx1v4   - tripolar ocn ice 1-degree grid  
-  tnx2v1   - tripolar ocn ice 2-degree grid  
-  tx0.25v4 - tripolar ocn ice 1/4-degree grid  
-
-
-Coupled
-^^^^^^^
-::
-
-  f19_tn14   - atm lnd 1.9x2.5, ocnice tnx1v4  [CMIP6 grid, NorESM2-LM]  
-  f09_tn14   - atm lnd 0.9x1.25, ocnice tnx1v4  [CMIP6 grid, NorESM2-MM]  
-  f09_tn0254 - atm lnd 0.9x1.25, ocnice tnx0.25v4  
-
-
-
-Forcing
-''''''''''''''''
-Please see :ref:`input`
-
-Choosing output
-'''''''''''''''
-please see :ref:`output`
-
-Setting up a nudged simulation
-''''''''''''''''''''''''''''''
-please see :ref:`nudged_simulations`

--- a/doc/configurations/input.rst
+++ b/doc/configurations/input.rst
@@ -3,7 +3,7 @@
 
 Input data sets
 ==============================
-The complete input data set is stored at Sigma2. To download, please refer to the **Downloading NorESM2 | Downloading inputdata** section. For uploading new input data, contact mben@norceresearch.no or the owner of the data.
+The complete input data set is stored at Sigma2. To download, please refer to the :ref:`download_input` section. For uploading new input data, contact mben@norceresearch.no or the owner of the data.
 
 Atmospheric specific input data
 ^^^^^^^^^^^^^^^

--- a/doc/configurations/newbie-guide.rst
+++ b/doc/configurations/newbie-guide.rst
@@ -17,59 +17,53 @@ Create a new case
 --------------------
 
 The **create_newcase** script is an excecutable python script located in:
-
 ::
 
   <noresm-base>/cime/scripts/
 
-::
-
 The script for creating a new case takes several command line arguments as input to know how to configure your case.
 Some of the most important arguments are as follows:
 
-  - ``-case`` defines a casename of your choice and created a folder by that name in <noresm-base>/cases/.
+  - ``--case`` defines a casename of your choice and creates a folder by that name. The argument respects absolute and relative paths (e.g. ``--case ../../cases/<casename>``).
 
-  - ``-mach`` defines the machine you will run the model on. The model NorESM2 has been configured to be run on a set of different machines (see list at :ref:`platforms`). If you are running the model on a machine not listed you will need to configure the model beyond this newbie guide. 
+  - ``--mach`` defines the machine you will run the model on. The model NorESM2 has been configured to be run on a set of different machines (see list at :ref:`platforms`). If you are running the model on a machine not listed you will need to configure the model beyond this newbie guide. 
 
-  - ``-res`` defines the resolution of your run. See :ref:`experiments` for more details.
+  - ``--res`` defines the resolution of your run. See :ref:`experiments` for more details.
 
-  - ``-compset`` defines what compset you will be using. A list of compsets for fully-coupled configurations can be found in the file <noresm_base>/cime_config/config_compsets.xml (see :ref:`amips` for compsets for AMIP-type simulations)
+  - ``--compset`` defines what compset you will be using. A list of compsets for fully-coupled configurations can be found in the file *<noresm_base>/cime_config/config_compsets.xml* (see :ref:`amips` for compsets for AMIP-type simulations)
 
-To investigate the full list of arguments, enter the <noresm_base>/cmie/scripts folder and run create_newcase with the --help argument:
+To investigate the full list of arguments, enter the *<noresm_base>/cime/scripts/* folder and run **create_newcase** with the ``--help`` argument:
 ::
     cd <noresm_base>/cime/scripts/
-  ./create_newcase --help
+    ./create_newcase --help
 
   
-To create a new case, enter the scripts directory and run the create_newcase scripts:
-:: 
-  cd <noresm_base>/cime/scripts/
-  ./create_newcase --case ../../cases/$CASENAME --mach $MACHINE --res f19_g16 --compset $COMPSET
+To create a new case, enter the scripts directory and run the **create_newcase** scripts:
+::
+    cd <noresm_base>/cime/scripts/
+    ./create_newcase --case ../../cases/$CASENAME --mach $MACHINE --res f19_g16 --compset $COMPSET
 
-You have now created the case folder <noresm_base>/cases/$CASENAME! Go to the case folder to start configuring your experiment.
+You have now created the case folder *<noresm_base>/cases/$CASENAME*! Go to the case folder to start configuring your experiment.
 
 More advanced examples
-++++++++
-The following example creates a case (test1910_1) on the machine Fram:
-
+++++++++++++++++++++++
+The following example creates the case *test1910_1* on the machine Fram:
 ::
 
     ./create_newcase --case ../../cases/test1910_1 --compset N1850 --res f19_tn14 --machine fram --project snic2019-1-2 --user-mods-dir cmip6_noresm_DECK 
 
-Here we use the N1850 compset, which configures the case as a 1850 pre-industrial control simulation. Note that we use the argument **--run-unsupported**, which required if the grid resolution is not supported in the compset (see :ref:`experiments`), **--project** to set the id of the project used in the batch system accounting on Fram, **--user-mods-dir**  to set the path to a folder containing files that will further configure your case (like user namelists, shell scripts with xmlchange commands or SourceMods).
+Here we use the *N1850* compset, which configures the case as a 1850 pre-industrial control simulation.  The argument ``--project`` should correspond to the id of the project used in the batch system accounting on Fram. The argument ``--user-mods-dir`` provides the path to a folder containing files that will further configure your case (like user namelists, shell scripts with xmlchange commands or SourceMods). The default location for this folder is under *<noresm_base>/cime_config/usermods_dirs/*.
 
-
-The following example creates a case (also called test1910_1), but on the machine Tetralith::
+The following example creates a case (also called *test1910_1*), but on the machine Tetralith:
 ::
 
     ./create_newcase --case ../../cases/test1910_1 --walltime 24:00:00 --compset N1850 --res f19_tn14 --machine tetralith --project snic2019-1-2 --output-root /proj/bolinc/users/${USER}/NorESM2/noresm2_out
     
-Note that here we use the argument **--output-root**, which is only required if the noresm_run_dir (the running directory of the mode) differs from default running directory <path_to_run_dir>/noresm/ 
+Note that here we use the argument ``--output-root``, which is only required if the *noresm_run_dir* (the running directory of the mode) differs from default running directory *<path_to_run_dir>/noresm/*. 
 
 Configure the case
 ---------------------
-The case folder `<noresm_base>/cases/$CASENAME/`` is where you configure your case by changing enviroment files (such as the <noresm_base>/cases/$CASENAME/env_run.xml file;see :ref:`experiment_environments`), changing the user namelists for the different model components (files named ``user_nl_$COMP`` where $COMP is a model component such as ``cam``), or even add your own code changes to ``SourceMods/src.$COMP/``. But for now we stick to the standard out-of-the-box set up and configure the case as follows:
-
+The case folder *<noresm_base>/cases/$CASENAME/* is where you configure your case by changing enviroment files (such as the *<noresm_base>/cases/$CASENAME/env_run.xml* file; see :ref:`experiment_environments`), changing the user namelists for the different model components (files named ``user_nl_$COMP`` where $COMP is a model component such as ``cam``), or even add your own code changes to ``SourceMods/src.$COMP/``. But for now we stick to the standard out-of-the-box set up and configure the case as follows:
 ::
 
   cd <noresm_base>/cases/$CASENAME

--- a/doc/configurations/platforms.rst
+++ b/doc/configurations/platforms.rst
@@ -8,7 +8,7 @@ HPC platforms
 
 Below is a list of platforms where NorESM2 has been installed, including platform specific intructions. 
 
-<noresm-base>: the name of the folder where the model code has been downloaded (cloned from git)
+**<noresm-base>**: the name of the folder where the model code has been downloaded (cloned from git)
 
 The configurations files with the platform specific settings are found in ::
   
@@ -27,15 +27,17 @@ Input data is stored in /cluster/shared/noresm/inputdata/
 
 Apply for membership in NorESM shared data storage (manager: mben@norceresearch.no) for access to the folder.
 
-The run and archive directories are stored /cluster/work/users/<user_name>/
+The run and archive directories are stored in /cluster/work/users/<user_name>/
 
 Create a new case: ::
 
-    ./create_newcase –case ../../../cases/<casename> --mach fram –-res <resolution> --compset <compset_name> --project <project_name> --user-mods-dir <user_mods_dir> --run-unsupported  
+    ./create_newcase --case ../../../cases/<casename> --mach fram --res <resolution> --compset <compset_name> --project <project_name> --user-mods-dir <user_mods_dir> --run-unsupported
 
 
 Betzy @ Sigma2
 ^^^^^^^^^^^^^
+NorESM2 working on BETZY with CIME tag cime5.6.10_cesm2_1_rel_06-Nor_v1.0.4
+
 Configuration files for running NorESM2 on Betzy are currently being put in all branches of the noresm code.
 
 Input data is stored in /cluster/shared/noresm/inputdata/
@@ -46,9 +48,34 @@ The run and archive directories are stored /cluster/work/users/<user_name>/
 
 Create a new case: ::
 
-    ./create_newcase –case ../../../cases/<casename> --mach betzy –-res <resolution> --compset <compset_name> --project <project_name> --user-mods-dir <user_mods_dir> --run-unsupported  
+    ./create_newcase --case ../../../cases/<casename> --mach betzy --res <resolution> --compset <compset_name> --project <project_name> --user-mods-dir <user_mods_dir> --run-unsupported
 
-**Please note that the Betzy settings are included in tag noresm2.0.3 and subsequent tags**  
+Setting number of nodes on Betzy
+-----------------
+In fully coupled setup, for grid f19_tn14 and f09_tn14, various processors configurations are added and can be used by setting ``--pecount`` = S, L, M or X1
+when creating a new case.
+
+For NorESM2-MM, using grid f09_tn14, ``--pecount`` will give the following number of nodes: ::
+
+    S = 4
+    M = 9
+    L = 15
+    X1 = 17
+
+and for NorESM2-LM, using grid f19_tn14, ``--pecount`` it will give the following number of nodes: ::
+
+    S = 4
+    M = 8
+    X1 = 10
+
+L does not exists for f19_tn14.
+
+E.g. creating a new case running on 4 nodes ::
+
+    ./create_newcase –case ../../../cases/<casename> --mach betzy –-res <resolution> --compset <compset_name> --project <project_name> --pecount= S --user-mods-dir <user_mods_dir> --run-unsupported  
+    
+ 
+**Please note that these Betzy settings are included in tag noresm2.0.4 and subsequent tags**  
 
 Queue options on Fram and on Betzy
 ------------------------
@@ -122,7 +149,7 @@ Input data is stored in /nobackup/forsk/noresm/inputdata/
 
 The run and archive directories are stored /nobackup/forsk/<user_name>/
 
-Before configuring and compiling the model, add export LMOD_QUIET=1 to your .bashrc
+Before configuring and compiling the model, add ``export LMOD_QUIET=1`` to your .bashrc
 
 ::
 
@@ -135,7 +162,7 @@ Create a new case:
 
 ::
 
-    ./create_newcase –case ../../../cases/<casename> --mach nebula –-res <resolution> --compset <compset_name> --project <project_name> --user-mods-dir <user_mods_dir> --run-unsupported  
+    ./create_newcase --case ../../../cases/<casename> --mach nebula --res <resolution> --compset <compset_name> --project <project_name> --user-mods-dir <user_mods_dir> --run-unsupported
 
 ::
 
@@ -181,7 +208,7 @@ Create a new case:
 
 ::
 
-./create_newcase –case ../../../cases/<casename> -mach triolith –res <resolution> -compset <compset_name> -pecount M -ccsm_out <NorESM_ouput_folder>
+    ./create_newcase --case ../../../cases/<casename> --mach triolith --res <resolution> --compset <compset_name> --pecount M --ccsm_out <NorESM_ouput_folder>
 
 ::
 

--- a/doc/faq/postp_plotting_faq.rst
+++ b/doc/faq/postp_plotting_faq.rst
@@ -3,6 +3,61 @@
 Post-processing and plotting FAQ
 ================
 
+Very large ocean cell thickness in NorESM2
+-----
+The ocean layer thickness **dz** variable may not be very meaningful for NorESM. The ocean model component BLOM is an isopycnic-coordinated model and hence the model layer thickness is changing from each integration step. Therefore, it is possible that the layer thickness will exceed 3km to 4km under certain circumstances. For example, this occurs sometimes in polar waters under deep convection where the ocean column is not stratified. And also at some coastal regions (where the water may not be well-represented by 'isopycnic' movement). So in short, **dz** reflects how the model represents the water masses (faithfully or not). 
+
+Weights and area information for the ocean component BLOM 
+--------
+The area and mask information for BLOM output can be found in the grid file usually stored together with the input data used by BLOM. Please see http://ns9560k.web.sigma2.no/inputdata/ocn/blom/grid/ for the grid files used. 
+
+Weights for ocean calculations:
+
+::
+
+  gridpath = 'path_to_gridfile' # path to grid files
+  grid = xr.open_mfdataset(gridpath + 'grid_tnx1v4_20170622.nc')
+  parea =  grid.parea
+  pmask =  grid.pmask
+  pweight = parea*pmask
+  
+::
+
+
+The vertical coordinate in BLOM
+---------------------------
+**Q:**
+The vertical coordinate of NorESM2 is provided as the isopycnal coordinate (kg/m^3). I want to change this isopycnal coordinate to z coordinate (m).
+
+**A:**
+Vertically pre-interpolated output to z-level (including temperature, salinity and the overturning mass stream-functions) should be available for all NorESM2 experiments. For raw model output these variables often end with *lvl* . E.g.
+
+- Temperature: templvl(time, depth, y, x)
+- Salinity: salnlvl(time, depth, y, x)
+- Velocity x-component: uvellvl(time, depth, y, x)
+- Velocity y-component: vvellvl(time, depth, y, x)
+- Overturning stream-function: mmflxd(time, region, depth, lat)
+
+For CMORIZED data the pre-interpolated output to z-level uses a different grid identifier than *gn* (grid native). Please note that *gr* usually means regridded horizontally but in case of NorESM2 it is regridded vertically. E.g.
+
+- Temperature: thetao(time, depth, y, x) on *gr* grid 
+- Salinity: so(time, depth, y, x) on *gr* grid 
+- Velocity x-component: uo(time, depth, y, x) on *gr* grid 
+- Velocity y-component: vo(time, depth, y, x) on *gr* grid 
+- Overturning stream-function: msftmz(time, region, depth, lat) on *grz* grid 
+
+Different sea-ice and ocean grid
+------------------------
+
+**Q:** The sea ice output variables in NorESM2 are on a 360x384 grid, while the ocean output variables are on a 360x385 grid. Which variable shall I use if I want to e.g. calculate the area sum of the sea ice  (e.g., sea ice volume in the Northern Hemisphere)?
+
+**A:**
+The ocean/sea-ice grid of NorESM2 is a tripolar grid with 360 and 384 unique grid cells in i- and j-direction, respectively. Due to the way variables are staggered in the ocean model, an additional j-row is required explaining the 385 grid cells in the j-direction for the ocean grid. The row with j=385 is a duplicate of the row with j=384, but with reverse i-index.
+
+The ocean and sea-ice components of NorESM define the grid cell area differently. In the ocean component, the grid cell area is found by computing the area of a spherical polygon with grid cell corners as vertices. The sea-ice component computes the area as dx*dy where dx and dy are grid cell sizes in i- and j-direction, respectively. In order to achieve good conservation in flux exchanges, we ensure that the ocean and sea-ice components have identical grid cell areas. To obtain this with the different approaches of computing grid cell area, we nudge the sea-ice grid locations slightly.
+
+In conclusion, it is consistent to use the area variable defined on the ocean grid in relation to sea-ice variables, but you have to ignore the final j-row of e.g. area. So to conclude, just drop the last row with j=385 of area when dealing with the sea ice variables.
+
 
 How do I compute a weighted average?
 ---------------------


### PR DESCRIPTION
This pull request copies the following files from the noresm2.0.5 release
- doc/
  - access/
    - download_code.rst
    - download_input.rst
  - configurations/
    - clm.rst
    - experiment_environment.rst
    - experiments.rst
    - input.rst
    - newbie-guide.rst
    - platforms.rst
  - faq/
    - postp_plotting_faq.rst

I think these files can be copied to master without any changes. Please let me know if there is something that should not be copied over from noresm2.0.5 or overwritten in master.