### PR TITLE
updated tags in Externals.cfg and Externals_continuous_development.cfg

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [cam]
-tag = cam_cesm2_1_rel_05-Nor_v1.0.3
+tag = cam_cesm2_1_rel_05-Nor_v1.0.4
 protocol = git
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam
@@ -28,7 +28,7 @@ externals = Externals_CISM.cfg
 required = False
 
 [clm]
-tag = release-clm5.0.14-Nor_v1.0.2
+tag = release-clm5.0.14-Nor_v1.0.3
 protocol = git
 repo_url = https://github.com/NorESMhub/ctsm
 local_path = components/clm

--- a/Externals_continuous_development.cfg
+++ b/Externals_continuous_development.cfg
@@ -13,7 +13,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_cesm2_1_rel_06-Nor
+tag = cime5.6.10_cesm2_1_rel_06-Nor-dev
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime


### PR DESCRIPTION
updated tags in Externals.cfg for CAM and CLM/CTSM : 
- makes all component tags equal to values used in branch noresm2 

updated tag (which refers to a branch) in Externals_continuous_development.cfg  for CIME :
- this CIME branch is aimed to contain new developments in the future