### PR TITLE
Avoid error on python >= 3.8

### DIFF
--- a/manage_externals/manic/sourcetree.py
+++ b/manage_externals/manic/sourcetree.py
@@ -261,7 +261,7 @@ class SourceTree(object):
         for comp in load_comps:
             printlog('{0}, '.format(comp), end='')
             stat = self._all_components[comp].status()
-            for name in stat.keys():
+            for name in list(stat.keys()):
                 # check if we need to append the relative_path_base to
                 # the path so it will be sorted in the correct order.
                 if not stat[name].path.startswith(relative_path_base):


### PR DESCRIPTION
Hot fix for "dictionary keys changed during iteration" error in issue #284 

