### PR TITLE
Add page for KeyCLIM experiments in the NorESM documentation

### DIFF
--- a/doc/data/data.rst
+++ b/doc/data/data.rst
@@ -9,4 +9,5 @@ Access NorESM data: CMIP and other
 
    cmip6_data.rst
    cmip5_data.rst
+   keyclim_data.rst
    happi_data.rst

--- a/doc/data/keyclim_data.rst
+++ b/doc/data/keyclim_data.rst
@@ -1,0 +1,30 @@
+.. _keyclim_data.rst
+
+KeyCLIM data
+=============
+
+Data is currently only available for NIRD users that are members of the NIRD storage project NS9252K.
+
+
+Experiments without anthropogenic aerosols
+^^^^^^^^^^^^^^^
+
+hist-piAerOxid
+++++++++++++
+
+As the CMIP6 historical experiment, but emissions of aerosols, emissions of aerosol pre-cursors, and oxidant concentrations (O3, OH, HO2, NO3) are kept at pre-industrial levels. 
+
+**Raw model output** is available on NIRD under:
+::
+   /projects/NS9252K/noresm/cases/NHISTpiaeroxid_f09_tn14_keyClim20201217/
+
+
+
+ssp370-piAerOxid
++++++++++++++
+
+As the CMIP6 SSP3-7.0 experiment, but emissions of aerosols, emissions of aerosol pre-cursors, and oxidant concentrations (O3, OH, HO2, NO3) are kept at pre-industrial levels. 
+
+**Raw model output** is available on NIRD under:
+::
+   /projects/NS9252K/noresm/cases/NSSP370piaeroxid_f09_tn14_keyClim20210210/


### PR DESCRIPTION
I've added a page for the KeyCLIM experiments in the documentation along with some placeholder content for the experiments that are already completed. Resolves #296.

The link to this page will be added to the metadata of the CMOR-ized files for the KeyCLIM experiments.

