### PR TITLE
add CMIP5/6 data description; small fix for diagnostic tool

### DIFF
--- a/doc/data/cmip6_data.rst
+++ b/doc/data/cmip6_data.rst
@@ -41,11 +41,11 @@ This is the same data that you can access through the ESGF. Note data is organiz
 
 **All NIRD users can access CMOR-ized CMIP6 data from multiple models under:** :: 
 
-   /projects/NS9252K/ESGF/
+   /projects/NS9252K/ESGF_betzy/
 
 , which has the same structure as data in /projects/NS9034K/CMIP6. Note only members of NS9252K, a NFR storage project for KeyCLIM have write permission.
 
-If you want to make a request for data or for more data to be downloaded to this folder, contact jang@met.no. If you are a NIRD user, but not a member of this project and would like to request access, contact michaels@met.no.
+Refer to Section: :ref:`cmip_other.rst` for more information on how to access and download new data.
 
 **NIRD users that are members of NS9560K (NFR storage project for INES) can access most of the raw (non-CMOR-ized) model data under**::
 

--- a/doc/data/cmip_other.rst
+++ b/doc/data/cmip_other.rst
@@ -89,13 +89,15 @@ A simply tutorial on how to use it to download and mange CMIP data.
 Activate the tool
 ++++++++++++++++
 
-It is install with ``Conda`` on the ipcc node (work for only the ipcc node), so you can load it by: ::
+Synda is installed with ``Conda`` Betzy, so you can load it by: ::
 
     conda activate /cluster/shared/ESGF/software/synda
 
-or just add ``synda`` exectable to your search path (work for the ipcc and normal nird nodes), e.g., ::
+or just add ``synda`` exectable to your search path, e.g., ::
 
+    mkdir -p ~/local/bin/synda
     ln -s /cluster/shared/ESGF/software/synda/bin/synda ~/local/bin/synda
+    echo 'export PATH=$PATH:~/local/bin' >>~/.bashrc
 
 Then it is availabe by the `synda` command.
 
@@ -104,7 +106,7 @@ Configuration
 
 You’ll need to properly configure the synda work environment. To do so, the first step is the set a synda home environment variable. This will the be the directory that will harbor all the configuration, database and other required files for synda to function properly. So choose it well. For instance: /home/user/.synda would do the trick. ::
 
-    export ST_HOME=/path/to/synda_home_directory
+    export ST_HOME=$HOME/.synda
 
 Set up your credentials
 +++++++++++++++++++++++

--- a/doc/data/cmip_other.rst
+++ b/doc/data/cmip_other.rst
@@ -82,7 +82,7 @@ It is currently installed at `/cluster/shared/ESGF/software/synda`.
 
 (Note, this just serves as an alternative to the tool/scripts [ESGF_download](https://github.com/metno/ESGF_download) by Jans)
 
-Refer to its [documentation](http://prodiguer.github.io/synda/) for introduction and user's guide. But be alerted that its documentation seems not well written and keeps up-to-date.
+Refer to its `documentation <http://prodiguer.github.io/synda/>`_ for introduction and user's guide. But be alerted that its documentation seems not well written and keeps up-to-date.
 
 A simply tutorial on how to use it to download and mange CMIP data.
 

--- a/doc/data/cmip_other.rst
+++ b/doc/data/cmip_other.rst
@@ -1,0 +1,156 @@
+.. _cmip_other.rst:
+
+Other CMIP5/6 data
+===================
+
+In addition to CMIP data by NorESM, some other CMIP5 and CMIP6 model and observational data are also downloaded and (currently) stored on Betzy, which is also accessible from NIRD. However, it is not a full replica of ESGF archive. Missing data can be downloaded from ESGF to directory /cluster/shared/ESGF/rawdata, see instructions below.
+
+.. note::
+    Data usage policy:
+    Users of the CMIP data copy are requested to respect the data policies of CMIP and acknowledge the KeyCLIM project for providing access to the data (acknowledgement shall be done in CRISTIN for any publication resulting of data usage taken from the nird data, KeyCLIM project number 295046).
+
+Data access
+^^^^^^^
+
+All Betzy users can access the (partial) replica of CMIP6 data under Betzy: ::
+
+   /cluster/share/ESGF
+   
+It contains CMIP5, CMIP6 and obs4MIPs datasets. These data are also accessible (read-only) on NIRD for members of NS9252K :: 
+
+   /projects/NS9252K/ESGF_betzy
+
+
+Data download
+^^^^^^^^^^^^
+There are two alternatives to download additional CMIP datasets:
+
+1. Make a request for data or for more data to be downloaded to this folder, contact jang@met.no.
+2. Download data by yourself, one can use the automatically-generated wget shell script on the ESGF data portal (e.g., `DKRZ ESGF portal <https://esgf-data.dkrz.de/projects/esgf-dkrz/>`_), or use the tool called `Synda <https://prodiguer.github.io/synda/index.html>`_ (Refer to the following subsection :ref:`download_with_synda`).
+   
+If you are a NIRD user, but not a member of this project and would like to request access, contact michaels@met.no.
+
+.. note::
+    NorESM CMIP data !!!  They are stored on nird under /pojects/NS9034K/ (not under /projects/NS9252K). You don't need to download NorESM data to avoid duplication.
+
+Data download guidline
+---------------------
+
+(This guidline is also noted in /cluster/shared/ESGF/README.)
+
+1. Download your data under (recommended, but OK to be elsewhere): ::
+
+    /cluster/shared/ESGF/rawdata/model
+
+2. After all downloaded, invoke the script ``move2autosort.sh`` to move data to ``/cluster/shared/ESGF/rawdata/autosort`` and automatically set correct file permission/ownership:
+
+For example: ::
+
+    $ cd /cluster/shared/ESGF/rawdata
+    $ ./move2autosort.sh "/cluster/shared/ESGF/rawdata/model/mydata*.nc"
+or  ::
+
+    $ ./move2autosort.sh "/cluster/shared/ESGF/rawdata/model/mydatafolder"
+
+.. note::
+    * You can create subfolders to organise the downloaded data
+    * Do NOT download data directly to /cluster/shared/ESGF/rawdata/autosort
+    * The data will start to be automatically sorted to ESGF/DKRZ folder structures within 30 minutes.
+    * The users can NOT invoke the 'raw2dkrz.sh' script anymore (since April 2022).
+
+3. If data are NOT sorted to the desired place, then:
+    - Check if they have been moved to: ``/cluster/shared/ESGF/rawdata/autosort/failed``
+    - If so, check what was going on in the recent log under: ``/cluster/shared/ESGF/rawdata/logs``
+
+.. note::
+    * If you are sure your dataset are correct, you can try to move your data under /cluster/shared/ESGF/rawdata/autosort/failed again back to /cluster/shared/ESGF/rawdata/autosort (simply by 'mv' or 'move2autosort.sh')
+    * Sometimes the HPC will be rebooted, and the crontab job to automatically sort the data will be swipped away. Or some internet problem so that the Synda connections can not be established correctly. 
+    * If there is still problem, please contact yanchun.he@nersc.no to report the error (but not for specific data download requests).
+
+.. _download_with_synda:
+
+Download data with Synda
+------------------------
+
+``Synda`` is installed under Betzy for downloading and managing CMIP data from ESGG.
+
+It is currently installed at `/cluster/shared/ESGF/software/synda`.
+
+(Note, this just serves as an alternative to the tool/scripts [ESGF_download](https://github.com/metno/ESGF_download) by Jans)
+
+Refer to its [documentation](http://prodiguer.github.io/synda/) for introduction and user's guide. But be alerted that its documentation seems not well written and keeps up-to-date.
+
+A simply tutorial on how to use it to download and mange CMIP data.
+
+Activate the tool
+++++++++++++++++
+
+It is install with ``Conda`` on the ipcc node (work for only the ipcc node), so you can load it by: ::
+
+    conda activate /cluster/shared/ESGF/software/synda
+
+or just add ``synda`` exectable to your search path (work for the ipcc and normal nird nodes), e.g., ::
+
+    ln -s /cluster/shared/ESGF/software/synda/bin/synda ~/local/bin/synda
+
+Then it is availabe by the `synda` command.
+
+Configuration
+++++++++++++++++
+
+You’ll need to properly configure the synda work environment. To do so, the first step is the set a synda home environment variable. This will the be the directory that will harbor all the configuration, database and other required files for synda to function properly. So choose it well. For instance: /home/user/.synda would do the trick. ::
+
+    export ST_HOME=/path/to/synda_home_directory
+
+Set up your credentials
++++++++++++++++++++++++
+
+1. register (one of) the `ESGF node <https://esgf-data.dkrz.de/projects/esgf-dkrz/>`_ and `Globus transfer <https://www.globus.org>`_ (not toally sure if account on globus is mandatory if this option will not be used, but seem yes according to my experience, you can firstly try without it)
+2. paste your username and password to in `~/.synda/conf/credentials.conf`
+3. configure `synda` parameters in `~/.synda/conf/sdt.conf`, use my setting as template (find them under `/cluster/shared/ESGF/software/noresmvaltool/synda/config/sdt.conf`.
+4. maybe you need get `globus token`.
+
+running the following command: ::
+
+    synda token -p globus renew
+
+it will give out something like: ::
+
+    Native App Authorization URL:
+    https://auth.globus.org/v2/oauth2/authorize?code_challenge=BrmiBhFVVuHVNyGDj6hn5N8M1-EKJNnNgptobIsbTqI&state=_default&redirect_uri=https%3A%2F%2Fauth.globus.org%2Fv2%2Fweb%2Fauth-code&response_type=code&client_id=83ec00c1-e67a-4356-9f1f-f7e31177e31a&scope=openid+email+profile+urn%3Aglobus%3Aauth%3Ascope%3Atransfer.api.globus.org%3Aall&code_challenge_method=S256&access_type=offline
+    Enter the auth code:
+
+paste the above https address to browser, and you will find a authen code, and past back to the command line.
+
+Examples to download data
++++++++++++++++++++++++++
+
+Firstly search the targeting datasets: ::
+
+    ## CMIP5 datasets
+    synda search -f project=CMIP5 model=NorESM1-M,NorESM1-ME variable=thetao,tos experiment=historical ensemble=r1i1p1 timeslice=200101-200612
+    synda search project=CMIP5 product=output1 institute=NCAR model=CCSM4 experiment=historical frequency=mon realm=atmos cmor_table=Amon ensemble=r1i1p1 latest=true variable=rlut timeslice=195001-200512 version=20160829
+
+    ## CMIP6 datasets
+    synda search project=CMIP6 activity_id=CMIP institution_id=NCC,EC-Earth-Consortium source_id=NorESM2-LM,EC-Earth3 table_id=Amon experiment_id=historical variable_id=tas variant_label=r1i1p1f1  latest=true
+    synda search project=CMIP6 activity_id=CMIP institution_id=NCC,EC-Earth-Consortium  source_id=NorESM2-LM,EC-Earth3 experiment_id=historical variant_label=r1i1p1f1 table_id=SImon variable_id=siconc grid_label=gn timeslice=197001-198901 latest=true
+
+It puts here as many as parameters to serve as a template, and you can tune these parameters as you like. And you can reduce the amount of facets/parameters.
+
+The above command gives you results: ::
+
+    new  CMIP6.CMIP.NCC.NorESM2-LM.historical.r1i1p1f1.Amon.tas.gn.v20190815
+    new  CMIP6.CMIP.EC-Earth-Consortium.EC-Earth3.historical.r1i1p1f1.Amon.tas.gr.v20200310
+
+Use ``synda search -f`` list all the matching files.
+
+each dataset contains several files, then download the dataset to the current directory, for example, ::
+
+    synda get CMIP6.CMIP.EC-Earth-Consortium.EC-Earth3.historical.r1i1p1f1.Amon.tas.gr.v20200310
+
+or individual file(s) by: ::
+
+    synda get CMIP6.CMIP.NCC.NorESM2-LM.historical.r1i1p1f1.Amon.tas.gn.v20190815.tas_Amon_NorESM2-LM_historical_r1i1p1f1_gn_201001-201412.nc
+
+(There are more examples on a github discussion group `esmvaltool-on-nird <https://github.com/orgs/NorESMhub/teams/esmvaltool-on-nird/discussions/5>`_ (and you may need to become a member to see the discussions). It is however out-dated now, and it was previously written for the data management routine under NIRD, but not under Betzy now.)
+

--- a/doc/data/cmip_other.rst
+++ b/doc/data/cmip_other.rst
@@ -80,7 +80,7 @@ Download data with Synda
 
 It is currently installed at `/cluster/shared/ESGF/software/synda`.
 
-(Note, this just serves as an alternative to the tool/scripts [ESGF_download](https://github.com/metno/ESGF_download) by Jans)
+(Note, this just serves as an alternative to the tool/scripts `ESGF_download <https://github.com/metno/ESGF_download>`_ by Jans)
 
 Refer to its `documentation <http://prodiguer.github.io/synda/>`_ for introduction and user's guide. But be alerted that its documentation seems not well written and keeps up-to-date.
 

--- a/doc/data/cmip_other.rst
+++ b/doc/data/cmip_other.rst
@@ -95,11 +95,11 @@ Synda is installed with ``Conda`` Betzy, so you can load it by: ::
 
 or just add ``synda`` exectable to your search path, e.g., ::
 
-    mkdir -p ~/local/bin/synda
+    mkdir -p ~/local/bin
     ln -s /cluster/shared/ESGF/software/synda/bin/synda ~/local/bin/synda
     echo 'export PATH=$PATH:~/local/bin' >>~/.bashrc
 
-Then it is availabe by the `synda` command.
+Then it is availabe by the ``synda`` command.
 
 Configuration
 ++++++++++++++++
@@ -107,6 +107,8 @@ Configuration
 You’ll need to properly configure the synda work environment. To do so, the first step is the set a synda home environment variable. This will the be the directory that will harbor all the configuration, database and other required files for synda to function properly. So choose it well. For instance: /home/user/.synda would do the trick. ::
 
     export ST_HOME=$HOME/.synda
+
+For more information, please refer to the `Synda documentation <https://prodiguer.github.io/synda/sdt/conda_install.html#configuration>`_
 
 Set up your credentials
 +++++++++++++++++++++++
@@ -157,6 +159,4 @@ each dataset contains several files, then download the dataset to the current di
 or individual file(s) by: ::
 
     synda get CMIP6.CMIP.NCC.NorESM2-LM.historical.r1i1p1f1.Amon.tas.gn.v20190815.tas_Amon_NorESM2-LM_historical_r1i1p1f1_gn_201001-201412.nc
-
-(There are more examples on a github discussion group `esmvaltool-on-nird <https://github.com/orgs/NorESMhub/teams/esmvaltool-on-nird/discussions/5>`_ (and you may need to become a member to see the discussions). It is however out-dated now, and it was previously written for the data management routine under NIRD, but not under Betzy now.)
 

--- a/doc/data/cmip_other.rst
+++ b/doc/data/cmip_other.rst
@@ -27,13 +27,17 @@ There are two alternatives to download additional CMIP datasets:
 
 1. Make a request for data or for more data to be downloaded to this folder, contact jang@met.no.
 2. Download data by yourself, one can use the automatically-generated wget shell script on the ESGF data portal (e.g., `DKRZ ESGF portal <https://esgf-data.dkrz.de/projects/esgf-dkrz/>`_), or use the tool called `Synda <https://prodiguer.github.io/synda/index.html>`_ (Refer to the following subsection :ref:`download_with_synda`).
+
+For either way to download the data, please follow the :ref:`data_download_guideline` to download and move your data to the right place so that it will be sorted to the DKRZ structure.
    
 If you are a NIRD user, but not a member of this project and would like to request access, contact michaels@met.no.
 
 .. note::
     NorESM CMIP data !!!  They are stored on nird under /pojects/NS9034K/ (not under /projects/NS9252K). You don't need to download NorESM data to avoid duplication.
 
-Data download guidline
+.. _data_download_guideline:
+
+Data download guideline
 ---------------------
 
 (This guidline is also noted in /cluster/shared/ESGF/README.)

--- a/doc/data/data.rst
+++ b/doc/data/data.rst
@@ -11,3 +11,4 @@ Access NorESM data: CMIP and other
    cmip5_data.rst
    keyclim_data.rst
    happi_data.rst
+   cmip_other.rst

--- a/doc/diagnostics/diag_run.rst
+++ b/doc/diagnostics/diag_run.rst
@@ -472,7 +472,7 @@ Run the tool on Betzy
 
 There are two alternatives to run the tool on Betzy, either as an interactive (for short test and debug runs) or a batch job (recommended). It is also possible to run directly on the login node with ``diag_run``, but it is higly discouraged and not an option (Refer to `Sigma2 HPC policy <https://documentation.sigma2.no/jobs/submitting.html>`_).
 
-The main purpose to run the tool on Betzy is to get a quick diagnostic of model output when the model is still on-the-fly, but already has some intermediate output been `short-term archived </output/archive_output.html#short-term-archiving>`_ to **/cluster/work/users/$USER/archive** (Refer to :ref:`archive_output`).
+The main purpose to run the tool on Betzy is to get a quick diagnostic of model output when the model is still on-the-fly, but already has some intermediate output been short-term archived to **/cluster/work/users/$USER/archive** (Refer to :ref:`archive_output`).
 
 Since the mounted NIRD project disks ``/trd-project*/xx`` are not accessible from the compute nodes, the ``-i``, ``-o`` have to point to ``/cluster/work/users/$USERS/xxx``, with an execption for the ``-w`` option. See explanations and examples in the following.
 
@@ -482,7 +482,7 @@ Run with an `intactive sbatch job <https://documentation.sigma2.no/jobs/interact
 
 Start an interactive job request by, for example : ::
 
-$ salloc --nodes=1 --mem-per-cpu=2G --time=00:30:00 --partition=preproc --account=nn2345k
+$ salloc --nodes=1 --mem-per-cpu=12G --time=00:30:00 --partition=preproc --account=nn2345k
 
 And then use the same command-line options of ``diag_run`` as on NIRD. 
 
@@ -600,3 +600,11 @@ The diagnostic tool package is based on NCAR's CAM and CLM Diagnostic Packages.
         1. Horizontal fields
         2. Zonal mean fields
         3. Regionally-averaged monthly climatologies
+
+*CISM_DIAG (newly developed)*
+
+    Two modes of diagnostics: compare to the observations and another model run; includes diagnostics of:
+
+    - Time series plots
+        1. Mass/ice fluxes
+        2. Mass/ice/temperatue averages

--- a/doc/output/archive_output.rst
+++ b/doc/output/archive_output.rst
@@ -5,6 +5,8 @@ Archiving NorESM output
 
 Archiving of NorESM output involves three distinct processes that serve different purposes. The medium-term and long-term archiving described here depend on services provided by `sigma2 <https://www.sigma2.no>`_, but the procedures may also be relevant for other systems. 
 
+.. _shortterm_archive:
+
 Short-term archiving
 ^^^^^^^^^^^^^^^^^^^^
 Short-term archiving is a phase of a NorESM model run where the generated output data is moved from ``$USERWORK/noresm/$CASE/run`` into a specific folder structure under ``$USERWORK/archive/$CASE``. Short-term archiving environment variables are set in the ``env_mach_specific.xml`` file and by default, short-term archiving is enabled. However, in the ``env_run.xml`` file it is possible to change short-term archiving settings by modifying several variables which control the behavior of short-term archiving:


### PR DESCRIPTION
* Add descriptions of CMIP5/6 datasets replica (ESGF) on Betzy
* Add data download guidlines
* minor fixes
    - increase memory allocation for interactive job for the noresm diagnostic tool (diag_run)