### PR TITLE
Provide more detailed example for BLOM user_nl_blom

### DIFF
--- a/doc/configurations/experiment_environment.rst
+++ b/doc/configurations/experiment_environment.rst
@@ -293,8 +293,9 @@ Note that BLOM uses a different syntax than the rest. In user_nl_blom::
 
   set BDMC2 = .15
   set NIWGF = .5
+  set SRF_ANO3 = 0, 2, 2
 
-you need to include **set** before the name of the variable and it does not matter what namelist group the variable belong.
+you need to include **set** before the name of the variable and it does not matter what namelist group the variable belong. To enable this handling of namelist parameters in BLOM, the namelist parameters require to be spelled in capital in both, user_nl_blom and cime_config/buildnml (the latter for developers, only).
 
 
 Input data

--- a/doc/configurations/experiment_environment.rst
+++ b/doc/configurations/experiment_environment.rst
@@ -295,7 +295,7 @@ Note that BLOM uses a different syntax than the rest. In user_nl_blom::
   set NIWGF = .5
   set SRF_ANO3 = 0, 2, 2
 
-you need to include **set** before the name of the variable and it does not matter what namelist group the variable belong. To enable this handling of namelist parameters in BLOM, the namelist parameters require to be spelled in capital in both, user_nl_blom and cime_config/buildnml (the latter for developers, only).
+you need to include **set** before the name of the variable and it does not matter what namelist group the variable belong. Input entries in user_nl_blom are case-insensitive (for model developers: variable names defined in the BLOM ``buildnml`` file should be capitalized to allow replacement values from user_nl_blom).
 
 
 Input data


### PR DESCRIPTION
The build system seem not to handle lower case written parameters for BLOM - so, in both, the ./components/blom/cime_config/buildnml and user_nl_blom, parameters need to be spelled capital. Further, no quotation marks are required when providing a vector as input - so I added  this as an additional example.