### PR TITLE
Data errors in FAQ

### DIFF
--- a/doc/faq/cmip6_data.rst
+++ b/doc/faq/cmip6_data.rst
@@ -1,6 +1,6 @@
 .. _cmip6_data.rst
 
-Cmorized (CMIP6) NorESM output 
+Reporting CMIP6 data errors
 ==========
 
 Data error(s)

--- a/doc/faq/cmip6_data.rst
+++ b/doc/faq/cmip6_data.rst
@@ -1,0 +1,19 @@
+.. _cmip6_data.rst
+
+Cmorized (CMIP6) NorESM output 
+==========
+
+Data error(s)
+------------
+
+If you encounter errors with the cmorized NorESM2 output published on ESGF, please create an issue here: https://github.com/NorESMhub/noresm2cmor
+including a precise and concise description of the data error.
+
+The ESGF Errata Service centralizes information about known issues of ESGF data, including the NorESM2 output published on ESGF. You can search for reported data errors here: https://errata.es-doc.org/static/index.html
+For NorESM2 output, please set ``Source ID`` to NorESM2-LM or NorESM2-MM, and/or ``Institution`` ID to NCC to solely list known NorESM data errors.
+
+Data problem(s)
+----------------
+If you encounter problems with the cmorized data, but are unsure if it is an error or not, feel free to create an issue here: https://github.com/NorESMhub/noresm2cmor or send us an email: noresm-ncc@met.no 
+
+Or maybe you just find the output a bit peculiar or your results unexpected? Feel free to start a discussion: https://github.com/NorESMhub/NorESM/discussions

--- a/doc/faq/faq.rst
+++ b/doc/faq/faq.rst
@@ -11,4 +11,4 @@ Frequently asked questions
    tech_faq.rst
    aero_faq.rst
    postp_plotting_faq.rst
-  
+   cmip6_data.rst


### PR DESCRIPTION
Hi,
after the last NorESM core meeting we decided to leave a note about known and unknown data errors on published NorESM data (ESGF). I made a section under FAQs, I'm not sure if that is the best place. Feel free to edit the text and/or suggest to move it somewhere else in the documentation.