### PR TITLE
Add a note about data errors in the CMIP6 archive section

### DIFF
--- a/doc/data/cmip6_data.rst
+++ b/doc/data/cmip6_data.rst
@@ -54,7 +54,7 @@ Refer to Section: :ref:`cmip_other.rst` for more information on how to access an
 If you are a NIRD user, but not a member of this project, and would like to request access, contact mben@norceresearch.no.
 
 .. note::
-    CMIP6 data errors: if encounter data errors/problems, please refer to the :ref:`cmip6_data_faqs.rst` section
+    CMIP6 data errors: if encounter data errors/problems, please refer to the :ref:`cmip6_data_faq.rst` section
     
 DECK contributions
 ^^^^^^^^^^^^^^^^^^

--- a/doc/data/cmip6_data.rst
+++ b/doc/data/cmip6_data.rst
@@ -53,6 +53,9 @@ Refer to Section: :ref:`cmip_other.rst` for more information on how to access an
    
 If you are a NIRD user, but not a member of this project, and would like to request access, contact mben@norceresearch.no.
 
+.. note::
+    CMIP6 data errors: if encounter data errors/problems, please refer to the :ref:`cmip6_data_faqs.rst` section
+    
 DECK contributions
 ^^^^^^^^^^^^^^^^^^
 NorESM2 contributions to the CMIP6 Diagnostic, Evaluation and Characterization of Klima (DECK) and CMIP6 historical simulations

--- a/doc/data/cmip6_data.rst
+++ b/doc/data/cmip6_data.rst
@@ -54,7 +54,7 @@ Refer to Section: :ref:`cmip_other.rst` for more information on how to access an
 If you are a NIRD user, but not a member of this project, and would like to request access, contact mben@norceresearch.no.
 
 .. note::
-    CMIP6 data errors: if encounter data errors/problems, please refer to the :ref:`cmip6_data_faq.rst` section
+    CMIP6 data errors: if you encounter data errors/problems, please refer to the :ref:`cmip6_data_faq.rst` section
     
 DECK contributions
 ^^^^^^^^^^^^^^^^^^

--- a/doc/faq/cmip6_data_faq.rst
+++ b/doc/faq/cmip6_data_faq.rst
@@ -1,4 +1,4 @@
-.. _cmip6_data_faqs.rst
+.. _cmip6_data_faq.rst
 
 Reporting CMIP6 data errors
 ==========

--- a/doc/faq/cmip6_data_faqs.rst
+++ b/doc/faq/cmip6_data_faqs.rst
@@ -1,4 +1,4 @@
-.. _cmip6_data.rst
+.. _cmip6_data_faqs.rst
 
 Reporting CMIP6 data errors
 ==========

--- a/doc/faq/faq.rst
+++ b/doc/faq/faq.rst
@@ -11,4 +11,4 @@ Frequently asked questions
    tech_faq.rst
    aero_faq.rst
    postp_plotting_faq.rst
-   cmip6_data.rst
+   cmip6_data_faq.rst


### PR DESCRIPTION
Hi,
I included a note under [Access NorESM data: CMIP and other] / 1. CMIP6 archive of NorESM results about reporting cmip6 data errors. I also changed the filename of cmip6_data.rst to cmip6_data_faq.rst, since cmip6_data.rst already exists under data

Ada