### PR TITLE
Fix cross referencing labels in some files.

### DIFF
--- a/doc/data/cmip6_data.rst
+++ b/doc/data/cmip6_data.rst
@@ -1,4 +1,4 @@
-.. _cmip6_data.rst
+.. _cmip6_data.rst:
 
 CMIP6 archive of NorESM results
 ===================
@@ -53,10 +53,9 @@ Refer to Section: :ref:`cmip_other.rst` for more information on how to access an
    
 If you are a NIRD user, but not a member of this project, and would like to request access, contact mben@norceresearch.no.
 
-CMIP6 data errors
-^^^^^
-If you encounter data errors/problems, please refer to the :ref:`cmip6_data_faq.rst` section
-    
+.. note::
+   **CMIP6 data errors:** If you encounter data errors/problems, please refer to the :ref:`cmip6_data_faq.rst` section
+
 DECK contributions
 ^^^^^^^^^^^^^^^^^^
 NorESM2 contributions to the CMIP6 Diagnostic, Evaluation and Characterization of Klima (DECK) and CMIP6 historical simulations

--- a/doc/data/happi_data.rst
+++ b/doc/data/happi_data.rst
@@ -1,4 +1,4 @@
-.. _happi_data.rst
+.. _happi_data.rst:
 
 HAPPI and HappiEVA data
 =============

--- a/doc/data/keyclim_data.rst
+++ b/doc/data/keyclim_data.rst
@@ -1,4 +1,4 @@
-.. _keyclim_data.rst
+.. _keyclim_data.rst:
 
 KeyCLIM data
 =============

--- a/doc/faq/cmip6_data_faq.rst
+++ b/doc/faq/cmip6_data_faq.rst
@@ -1,4 +1,4 @@
-.. _cmip6_data_faq.rst
+.. _cmip6_data_faq.rst:
 
 Reporting CMIP6 data errors
 ==========

--- a/doc/faq/discussion.rst
+++ b/doc/faq/discussion.rst
@@ -1,4 +1,4 @@
-.. discussion.rst:
+.. _discussion.rst:
 
 Low-key discussion forum
 ======


### PR DESCRIPTION
Some of the files did not have the correct cross-referencing label format `_<label>:` on the top line.