### PR TITLE
Suppress warnings about orphan files not in toctree.

### DIFF
--- a/doc/configurations/amips.rst
+++ b/doc/configurations/amips.rst
@@ -32,26 +32,23 @@ In addition some parameter settings, emisson and input files will differ from st
 The different source directories are included/activated in the following way:
 
 1. In ``components/cam/cime_config/config_component.xml``
-  If the long compset name contains ::
-  
-      _CAM60%NORESM 
-  
-  
-  or ::
-  
-      _CAM60%PTAERO
-  
-  
-  then CAM_CONFIG_OPTS will contain ``-chem trop_mam_oslo``.
+   If the long compset name contains ::
 
+        _CAM60%NORESM
+
+   or ::
+
+       _CAM60%PTAERO
+
+   then CAM_CONFIG_OPTS will contain ``-chem trop_mam_oslo``.
 
 2. In components/cam/bld/configure:
-  If chem contains the string ``_oslo``, the following two directories are added as source ::
-  
-      cam/src/chemistry/oslo_aero
-      cam/src/physics/cam_oslo
+   If chem contains the string ``_oslo``, the following two directories are added as source ::
 
-  The directory ``cam/src/chemistry/pp_$chem_pkg`` (in our case thus ``pp_trop_mam_oslo``) will be added as source.
+       cam/src/chemistry/oslo_aero
+       cam/src/physics/cam_oslo
+
+   The directory ``cam/src/chemistry/pp_$chem_pkg`` (in our case thus ``pp_trop_mam_oslo``) will be added as source.
 
 
 The following two directories are always added [this should in principle not be the case for a pure CESM compset, but that switch hasn't been built in yet]::
@@ -139,7 +136,7 @@ E.g.
   HIST_CAM60%NORESM%NORNC
     * Forcing and input files read from historical conditions (1850 - 2015)
     * Build CAM6.0 (the atmosphere model) with NorESM specific additions and NorESM derived boundary conditions  (for the boundary conditions, please see explonation below).
-    Note for some AMIP compsets CAM60%PTAERO may be used instead of CAM60%NORESM. Don't worry, those are identical.
+    * Note for some AMIP compsets CAM60%PTAERO may be used instead of CAM60%NORESM. Don't worry, those are identical.
 
   CLM50%BGC-CROP
     * Build CLM5 (land model) with a global crop model (interactive vegetation)

--- a/doc/configurations/output.rst
+++ b/doc/configurations/output.rst
@@ -1,4 +1,5 @@
 .. _output:
+:orphan:
 
 Output and standard results
 ===================================

--- a/doc/configurations/output.rst
+++ b/doc/configurations/output.rst
@@ -1,5 +1,5 @@
-.. _output:
 :orphan:
+.. _output:
 
 Output and standard results
 ===================================

--- a/doc/configurations/simplified_models.rst
+++ b/doc/configurations/simplified_models.rst
@@ -1,4 +1,5 @@
 .. _simplified_models:
+:orphan:
 
 Simplified setup
 '''''''''''''''''''''''

--- a/doc/configurations/simplified_models.rst
+++ b/doc/configurations/simplified_models.rst
@@ -1,5 +1,5 @@
-.. _simplified_models:
 :orphan:
+.. _simplified_models:
 
 Simplified setup
 '''''''''''''''''''''''

--- a/doc/output/aerosol_output_aerocom_variables.rst
+++ b/doc/output/aerosol_output_aerocom_variables.rst
@@ -1,5 +1,5 @@
-.. _aerosol_output_aerocom_variables:
 :orphan:
+.. _aerosol_output_aerocom_variables:
 
 AEROCOM extra output
 ''''''''''''''''''''

--- a/doc/output/aerosol_output_aerocom_variables.rst
+++ b/doc/output/aerosol_output_aerocom_variables.rst
@@ -1,4 +1,5 @@
 .. _aerosol_output_aerocom_variables:
+:orphan:
 
 AEROCOM extra output
 ''''''''''''''''''''

--- a/doc/output/aerosol_output_aeroffl_variables.rst
+++ b/doc/output/aerosol_output_aeroffl_variables.rst
@@ -1,5 +1,5 @@
-.. _aerosol_output_aeroffl_variables:
 :orphan:
+.. _aerosol_output_aeroffl_variables:
 
 AEROFFL extra output
 ''''''''''''''''''''

--- a/doc/output/aerosol_output_aeroffl_variables.rst
+++ b/doc/output/aerosol_output_aeroffl_variables.rst
@@ -1,4 +1,5 @@
 .. _aerosol_output_aeroffl_variables:
+:orphan:
 
 AEROFFL extra output
 ''''''''''''''''''''

--- a/doc/output/aerosol_output_history_aerosol_variables.rst
+++ b/doc/output/aerosol_output_history_aerosol_variables.rst
@@ -1,5 +1,5 @@
-.. _aerosol_output_history_aerosol_variables:
 :orphan:
+.. _aerosol_output_history_aerosol_variables:
 
 history_aerosol extra output
 ''''''''''''''''''''''''''''

--- a/doc/output/aerosol_output_history_aerosol_variables.rst
+++ b/doc/output/aerosol_output_history_aerosol_variables.rst
@@ -1,5 +1,6 @@
 .. _aerosol_output_history_aerosol_variables:
- 
+:orphan:
+
 history_aerosol extra output
 ''''''''''''''''''''''''''''
 

--- a/doc/output/blom_standard_out.rst
+++ b/doc/output/blom_standard_out.rst
@@ -1,5 +1,5 @@
-.. _blom_standard_out:
 :orphan:
+.. _blom_standard_out:
 
 BLOM standard set-up output  
 ''''''''''''''''''''''''''''''

--- a/doc/output/blom_standard_out.rst
+++ b/doc/output/blom_standard_out.rst
@@ -1,4 +1,5 @@
 .. _blom_standard_out:
+:orphan:
 
 BLOM standard set-up output  
 ''''''''''''''''''''''''''''''

--- a/doc/output/cam_standard_out.rst
+++ b/doc/output/cam_standard_out.rst
@@ -1,5 +1,5 @@
-.. _cam_standard_out:
 :orphan:
+.. _cam_standard_out:
 
 CAM6-Nor standard set-up output
 '''''''''''''''''''''''''''''''''

--- a/doc/output/cam_standard_out.rst
+++ b/doc/output/cam_standard_out.rst
@@ -1,4 +1,5 @@
 .. _cam_standard_out:
+:orphan:
 
 CAM6-Nor standard set-up output
 '''''''''''''''''''''''''''''''''

--- a/doc/output/cice_standard_out.rst
+++ b/doc/output/cice_standard_out.rst
@@ -1,5 +1,5 @@
-.. _cice_standard_out:
 :orphan:
+.. _cice_standard_out:
 
 CICE stadard set-up output
 '''''''''''''''''''''''''''''

--- a/doc/output/cice_standard_out.rst
+++ b/doc/output/cice_standard_out.rst
@@ -1,4 +1,5 @@
 .. _cice_standard_out:
+:orphan:
 
 CICE stadard set-up output
 '''''''''''''''''''''''''''''

--- a/doc/output/clm_standard_out.rst
+++ b/doc/output/clm_standard_out.rst
@@ -1,5 +1,5 @@
-.. _clm_standard_out:
 :orphan:
+.. _clm_standard_out:
 
 CLM5 standard set-up output
 ''''''''''''''''''''''''''''

--- a/doc/output/clm_standard_out.rst
+++ b/doc/output/clm_standard_out.rst
@@ -1,4 +1,5 @@
 .. _clm_standard_out:
+:orphan:
 
 CLM5 standard set-up output
 ''''''''''''''''''''''''''''

--- a/doc/output/cosp_extra_output.rst
+++ b/doc/output/cosp_extra_output.rst
@@ -1,5 +1,5 @@
-.. _cosp_extra_output:
 :orphan:
+.. _cosp_extra_output:
 
 COSP extra output
 '''''''''''''''''

--- a/doc/output/cosp_extra_output.rst
+++ b/doc/output/cosp_extra_output.rst
@@ -1,4 +1,5 @@
 .. _cosp_extra_output:
+:orphan:
 
 COSP extra output
 '''''''''''''''''

--- a/doc/output/hamocc_standard_out.rst
+++ b/doc/output/hamocc_standard_out.rst
@@ -1,5 +1,5 @@
-.. _hamocc_standard_out:
 :orphan:
+.. _hamocc_standard_out:
 
 iHAMOCC standard set-up output
 ''''''''''''''''''''''''''''''''''

--- a/doc/output/hamocc_standard_out.rst
+++ b/doc/output/hamocc_standard_out.rst
@@ -1,4 +1,5 @@
 .. _hamocc_standard_out:
+:orphan:
 
 iHAMOCC standard set-up output
 ''''''''''''''''''''''''''''''''''

--- a/doc/output/mosart_standard_out.rst
+++ b/doc/output/mosart_standard_out.rst
@@ -1,5 +1,5 @@
-.. _mosart_standard_out:
 :orphan:
+.. _mosart_standard_out:
 
 MOSART standard set-up output
 ''''''''''''''''''''''''''''''

--- a/doc/output/mosart_standard_out.rst
+++ b/doc/output/mosart_standard_out.rst
@@ -1,4 +1,5 @@
 .. _mosart_standard_out:
+:orphan:
 
 MOSART standard set-up output
 ''''''''''''''''''''''''''''''


### PR DESCRIPTION
This should suppress warnings about orphan files not being in a toctree. I'm not sure if this is what we really want, but it could be an option if we want to "hide" some files but keep the content available.