### PR TITLE
updated component tags in Externals.cfg in preparation of noresm-2.0.6

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [cam]
-tag = cam_cesm2_1_rel_05-Nor_v1.0.4
+tag = cam_cesm2_1_rel_05-Nor_v1.0.5
 protocol = git
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam
@@ -13,7 +13,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_cesm2_1_rel_06-Nor_v1.0.5
+tag = cime5.6.10_cesm2_1_rel_06-Nor_v1.0.6
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime
@@ -28,7 +28,7 @@ externals = Externals_CISM.cfg
 required = False
 
 [clm]
-tag = release-clm5.0.14-Nor_v1.0.3
+tag = release-clm5.0.14-Nor_v1.0.4
 protocol = git
 repo_url = https://github.com/NorESMhub/ctsm
 local_path = components/clm
@@ -51,7 +51,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = v1.1.0
+tag = v1.3.0
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom


### PR DESCRIPTION
updated component tags in Externals.cfg in preparation of noresm-2.0.6 release :
* cam : cam_cesm2_1_rel_05-Nor_v1.0.5
* clm : release-clm5.0.14-Nor_v1.0.4
* cime : cime5.6.10_cesm2_1_rel_06-Nor_v1.0.6
* cice (not changed)
* cism : wrapper_noresm2.0.6_v0 (was already changed in earlier commit)
* blom : v1.3.0
* mosart (not changed)