### PR TITLE
From noresm2: Update Externals*.cfg files

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [cam]
-tag = cam_cesm2_1_rel_05-Nor_v1.0.4
+tag = cam_cesm2_1_rel_05-Nor_v1.0.5
 protocol = git
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam
@@ -13,14 +13,14 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_cesm2_1_rel_06-Nor_v1.0.5
+tag = cime5.6.10_cesm2_1_rel_06-Nor_v1.0.6
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime
 required = True
 
 [cism]
-tag = wrapper_noresm2.0.2_v1
+tag = wrapper_noresm2.0.6_v0
 protocol = git
 repo_url = https://github.com/NorESMhub/cism-wrapper
 local_path = components/cism
@@ -28,7 +28,7 @@ externals = Externals_CISM.cfg
 required = False
 
 [clm]
-tag = release-clm5.0.14-Nor_v1.0.3
+tag = release-clm5.0.14-Nor_v1.0.4
 protocol = git
 repo_url = https://github.com/NorESMhub/ctsm
 local_path = components/clm
@@ -51,10 +51,11 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = v1.1.0
+tag = v1.3.0
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom
+externals = Externals_BLOM.cfg
 required = True
 
 [rtm]

--- a/Externals_continuous_development.cfg
+++ b/Externals_continuous_development.cfg
@@ -1,34 +1,34 @@
 [cam]
-tag = cam-Nor-dev
+branch = cam_cesm2_1_rel_05-Nor
 protocol = git
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam
 required = True
 
 [cice]
-tag = cice5_20181109-Nor
+branch = cice5_20181109-Nor
 protocol = git
 repo_url = https://github.com/NorESMHub/CESM_CICE5
 local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_cesm2_1_rel_06-Nor-dev
+branch = cime5.6.10_cesm2_1_rel_06-Nor
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime
 required = True
 
 [cism]
-tag = release-cesm2.0.04
+branch = wrapper_noresm2
 protocol = git
-repo_url = https://github.com/ESCOMP/cism-wrapper
+repo_url = https://github.com/NorESMhub/cism-wrapper
 local_path = components/cism
 externals = Externals_CISM.cfg
 required = False
 
 [clm]
-tag = clm-Nor-dev
+branch = release-clm5.0.14-Nor
 protocol = git
 repo_url = https://github.com/NorESMhub/ctsm
 local_path = components/clm
@@ -36,7 +36,7 @@ externals = Externals_CLM.cfg
 required = True
 
 [mosart]
-tag = release-cesm2.0.03-Nor
+branch = release-cesm2.0.03-Nor
 protocol = git
 repo_url = https://github.com/NorESMhub/mosart
 local_path = components/mosart
@@ -51,10 +51,11 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = release-1.0
+branch = release-1.3
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom
+externals = Externals_BLOM.cfg
 required = True
 
 [rtm]


### PR DESCRIPTION
Update Externals.cfg and Externals_continuous_development.cfg files from `noresm2` branch, but keep the original norcpm option intact.