### PR TITLE
updates to most externals

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -51,7 +51,7 @@ required = True
 
 [blom]
 protocol = git
-tag = 2bb8e7c09d95f37b83bceead851f856a911ac4b8
+tag = 1d71682961d242493a7cb0416b60fe60af7fbc27
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom
 externals = Externals_BLOM.cfg
@@ -59,7 +59,7 @@ required = True
 
 [cam]
 protocol = git
-tag = noresm_v4_cam6_3_112
+tag = noresm_v7_cam6_3_123
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg
@@ -83,7 +83,7 @@ required = True
 
 [cmeps]
 protocol = git
-tag = cmeps0.14.32_noresm_v2
+tag = cmeps0.14.32_noresm_v3
 repo_url = https://github.com/NorESMhub/CMEPS.git
 local_path = components/cmeps
 required = True
@@ -98,7 +98,7 @@ required = True
 
 [clm]
 protocol = git
-tag = ctsm5.1dev130-noresm_v1
+tag = ctsm5.1.dev142-noresm_v0
 repo_url = https://github.com/NorESMhub/CTSM
 local_path = components/clm
 externals = Externals_CLM.cfg
@@ -120,7 +120,7 @@ required = True
 
 [ww3dev]
 protocol = git
-tag = ww3_interface_noresm0.0.9
+ww3_interface_noresm0.0.11
 repo_url = https://github.com/NorESMhub/WW3_interface
 local_path = components/ww3dev
 externals = Externals.cfg

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -22,7 +22,7 @@ required = True
 
 [ccs_config]
 protocol = git
-tag = ccs_config_noresm0.0.12
+tag = ccs_config_noresm0.0.21
 repo_url = https://github.com/NorESMhub/ccs_config_noresm.git
 local_path = ccs_config
 required = True


### PR DESCRIPTION
Primarily updates to CAM to point to new oslo-aero repositories, updates to BLOM to point to new build-namelist and removal of HAMOCC #ifdefs, updates to CLM for FATES. Propose to tag this as noresm2.5_alpha01.