### PR TITLE
Externals updates for NorESM2.1 release

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -51,7 +51,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-hash = f5dd74de2a34803648a5683b1971e0bbe5a8ec42
+tag = v1.5.0
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [cam]
-tag = cam_cesm2_1_rel_05-Nor_v1.0.5
+tag = cam_noresm2_1_v1.0.0
 protocol = git
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam
@@ -13,7 +13,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_cesm2_1_rel_06-Nor_v1.0.7
+tag = cime5.6.10_cesm2_1_rel_06-Nor_v1.0.8
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime
@@ -51,7 +51,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = v1.3.0
+hash = f5dd74de2a34803648a5683b1971e0bbe5a8ec42
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom


### PR DESCRIPTION
Update Externals.cfg for the NorESM2.1 release

- Update CIME tag to cime5.6.10_cesm2_1_rel_06-Nor_v1.0.8
- Update CAM tag to cam_noresm2_1_v1.0.0
- Update BLOM tag to v1.5.0

closes #480 
closes #481 
closes #479 
closes #470
