### PR TITLE
noresm2_5_alpha01: Initial tag

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -22,7 +22,7 @@ required = True
 
 [ccs_config]
 protocol = git
-tag = ccs_config_noresm0.0.21
+tag = ccs_config_noresm0.0.23
 repo_url = https://github.com/NorESMhub/ccs_config_noresm.git
 local_path = ccs_config
 required = True
@@ -51,7 +51,11 @@ required = True
 
 [blom]
 protocol = git
+<<<<<<< HEAD
 tag = 1d71682961d242493a7cb0416b60fe60af7fbc27
+=======
+tag = v1.5.0
+>>>>>>> feature/averaging_for_partitions
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom
 externals = Externals_BLOM.cfg
@@ -59,7 +63,11 @@ required = True
 
 [cam]
 protocol = git
+<<<<<<< HEAD
 tag = noresm_v7_cam6_3_123
+=======
+tag = noresm_v8_cam6_3_123
+>>>>>>> feature/averaging_for_partitions
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg
@@ -83,8 +91,13 @@ required = True
 
 [cmeps]
 protocol = git
+<<<<<<< HEAD
 tag = cmeps0.14.32_noresm_v3
 repo_url = https://github.com/NorESMhub/CMEPS.git
+=======
+tag = cmeps0.14.32_noresm_v4
+repo_url  = https://github.com/NorESMhub/CMEPS.git
+>>>>>>> feature/averaging_for_partitions
 local_path = components/cmeps
 required = True
 
@@ -98,7 +111,11 @@ required = True
 
 [clm]
 protocol = git
+<<<<<<< HEAD
 tag = ctsm5.1.dev142-noresm_v0
+=======
+tag = ctsm5.1.dev151-noresm_v1
+>>>>>>> feature/averaging_for_partitions
 repo_url = https://github.com/NorESMhub/CTSM
 local_path = components/clm
 externals = Externals_CLM.cfg
@@ -120,7 +137,11 @@ required = True
 
 [ww3dev]
 protocol = git
+<<<<<<< HEAD
 ww3_interface_noresm0.0.11
+=======
+tag = ww3_interface_noresm0.0.12
+>>>>>>> feature/averaging_for_partitions
 repo_url = https://github.com/NorESMhub/WW3_interface
 local_path = components/ww3dev
 externals = Externals.cfg

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -51,11 +51,7 @@ required = True
 
 [blom]
 protocol = git
-<<<<<<< HEAD
-tag = 1d71682961d242493a7cb0416b60fe60af7fbc27
-=======
 tag = v1.5.0
->>>>>>> feature/averaging_for_partitions
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom
 externals = Externals_BLOM.cfg
@@ -63,11 +59,7 @@ required = True
 
 [cam]
 protocol = git
-<<<<<<< HEAD
-tag = noresm_v7_cam6_3_123
-=======
 tag = noresm_v8_cam6_3_123
->>>>>>> feature/averaging_for_partitions
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg
@@ -91,13 +83,8 @@ required = True
 
 [cmeps]
 protocol = git
-<<<<<<< HEAD
-tag = cmeps0.14.32_noresm_v3
-repo_url = https://github.com/NorESMhub/CMEPS.git
-=======
 tag = cmeps0.14.32_noresm_v4
 repo_url  = https://github.com/NorESMhub/CMEPS.git
->>>>>>> feature/averaging_for_partitions
 local_path = components/cmeps
 required = True
 
@@ -111,11 +98,7 @@ required = True
 
 [clm]
 protocol = git
-<<<<<<< HEAD
-tag = ctsm5.1.dev142-noresm_v0
-=======
 tag = ctsm5.1.dev151-noresm_v1
->>>>>>> feature/averaging_for_partitions
 repo_url = https://github.com/NorESMhub/CTSM
 local_path = components/clm
 externals = Externals_CLM.cfg
@@ -137,11 +120,7 @@ required = True
 
 [ww3dev]
 protocol = git
-<<<<<<< HEAD
-ww3_interface_noresm0.0.11
-=======
 tag = ww3_interface_noresm0.0.12
->>>>>>> feature/averaging_for_partitions
 repo_url = https://github.com/NorESMhub/WW3_interface
 local_path = components/ww3dev
 externals = Externals.cfg

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -77,7 +77,7 @@
       </pes>
     </mach>
   </grid>
-  
+
   <grid name="a%ne30np4.+l%ne30np4.+oi%gx1" >
     <mach name="any">
       <pes pesize="any" compset="any">
@@ -461,7 +461,7 @@
 
   <grid name="a%1.9x2.5.+l%1.9x2.5.+oi%tnx1v4" >
     <mach name="fram">
-      <pes pesize="any" compset="CAM60%PTAERO.+CLM50%BGC-CROP.+CICE.+BLOM%ECO">
+      <pes pesize="any" compset="CAM60%NORESM.+CLM50%BGC-CROP.+CICE.+BLOM%ECO">
         <comment>none</comment>
         <ntasks>
           <ntasks_atm>768</ntasks_atm>


### PR DESCRIPTION
This is the first tag in the noresm2_5 alpha series and has as highlights:
- updates for CAM running with the modularized oslo-aero
- Fixes issue with GitHub ending support for its svn bridge (used to trim sub-component checkout size)
- new changes in CMEPS and ww3dev for writing auxiliary files for time averaged wave fields (WW3 does not have any ability to do time averages in output history)
- the latest BLOM tag with new namelist functionality and a refactored HAMOCC

Testing: since the main purpose of this tag is to allow science to occur with ww3dev - the following configuration was verified for restarts:
-`-compset 2000_CAM60_CLM50%SP_CICE_BLOM_MOSART_SGLC_WW3DEV_SESP --res f19_tn14_wtn14nw --user-mods $SRCROOT/cime_config/usermods_dirs/wav_ice_coupling --mach betzy `
And the following namelists were set in user_nl_cpl
```wav_coupling_to_cice=.true.
histaux_wav2med_file1_enabled = .true.
```

closes #485 
closes #488