### PR TITLE
release-noresm2.1.0a2: Externals and fixes needed for NorESM2.1

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [cam]
-tag = cam_noresm2_1_v1.0.0
+tag = cam_noresm2_1_v1.0.1
 protocol = git
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam
@@ -13,7 +13,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_cesm2_1_rel_06-Nor_v1.0.8
+tag = cime5.6.10_NorESM2_1_r3
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime
@@ -28,7 +28,7 @@ externals = Externals_CISM.cfg
 required = False
 
 [clm]
-tag = release-clm5.0.14-Nor_v1.0.4
+tag = release-clm5.0.14-Nor_v1.0.5
 protocol = git
 repo_url = https://github.com/NorESMhub/ctsm
 local_path = components/clm
@@ -51,7 +51,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = v1.5.0
+tag = v1.5.1
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -41,16 +41,12 @@
   <compset>
     <alias>B1850</alias>
     <lname>1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
-    <science_support grid="f09_g17_gl4"/>
-    <science_support grid="f09_g17"/>
   </compset>
 
   <!-- Same as B1850, but with cmip6-related modifiers for some components -->
   <compset>
     <alias>B1850cmip6</alias>
     <lname>1850_CAM60_CLM50%BGC-CROP-CMIP6DECK_CICE%CMIP6_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
-    <science_support grid="f09_g17_gl4"/>
-    <science_support grid="f09_g17"/>
   </compset>
 
   <compset>
@@ -66,16 +62,12 @@
   <compset>
     <alias>BW1850</alias>
     <lname>1850_CAM60%WCTS_CLM50%BGC-CROP_CICE_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3</lname>
-    <science_support grid="f09_g17_gl4"/>
-    <science_support grid="f09_g17"/>
   </compset>
 
   <!-- Same as BW1850, but with cmip6-related modifiers for some components -->
   <compset>
     <alias>BW1850cmip6</alias>
     <lname>1850_CAM60%WCTS_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3</lname>
-    <science_support grid="f09_g17_gl4"/>
-    <science_support grid="f09_g17"/>
   </compset>
 
   <compset>
@@ -101,16 +93,12 @@
   <compset>
     <alias>BWHIST</alias>
     <lname>HIST_CAM60%WCTS_CLM50%BGC-CROP_CICE_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3</lname>
-    <science_support grid="f09_g17_gl4"/>
-    <science_support grid="f09_g17"/>
   </compset>
 
   <!-- Same as BWHIST, but with cmip6-related modifiers for some components -->
   <compset>
     <alias>BWHISTcmip6</alias>
     <lname>HIST_CAM60%WCTS_CLM50%BGC-CROP-CMIP6WACCMDECK_CICE%CMIP6_POP2%ECO%NDEP_MOSART_CISM2%NOEVOLVE_WW3</lname>
-    <science_support grid="f09_g17_gl4"/>
-    <science_support grid="f09_g17"/>
   </compset>
 
   <compset>
@@ -121,16 +109,12 @@
   <compset>
     <alias>BHIST</alias>
     <lname>HIST_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
-    <science_support grid="f09_g17_gl4"/>
-    <science_support grid="f09_g17"/>
   </compset>
 
   <!-- Same as BHIST, but with cmip6-related modifiers for some components -->
   <compset>
     <alias>BHISTcmip6</alias>
     <lname>HIST_CAM60_CLM50%BGC-CROP-CMIP6DECK_CICE%CMIP6_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
-    <science_support grid="f09_g17_gl4"/>
-    <science_support grid="f09_g17"/>
   </compset>
 
   <compset>
@@ -199,58 +183,42 @@
   <compset>
     <alias>BSSP585</alias>
     <lname>SSP585_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
-    <science_support grid="f09_g17_gl4"/>
-    <science_support grid="f09_g17"/>
   </compset>
 
   <compset>
     <alias>BSSP126</alias>
     <lname>SSP126_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
-    <science_support grid="f09_g17_gl4"/>
-    <science_support grid="f09_g17"/>
   </compset>
 
   <compset>
     <alias>BSSP245</alias>
     <lname>SSP245_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
-    <science_support grid="f09_g17_gl4"/>
-    <science_support grid="f09_g17"/>
   </compset>
 
   <compset>
     <alias>BSSP370</alias>
     <lname>SSP370_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
-    <science_support grid="f09_g17_gl4"/>
-    <science_support grid="f09_g17"/>
   </compset>
 
   <!-- Same as above, but with cmip6-related modifiers for some components -->
   <compset>
     <alias>BSSP585cmip6</alias>
     <lname>SSP585_CAM60_CLM50%BGC-CROP-CMIP6DECK_CICE%CMIP6_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
-    <science_support grid="f09_g17_gl4"/>
-    <science_support grid="f09_g17"/>
   </compset>
 
   <compset>
     <alias>BSSP126cmip6</alias>
     <lname>SSP126_CAM60_CLM50%BGC-CROP-CMIP6DECK_CICE%CMIP6_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
-    <science_support grid="f09_g17_gl4"/>
-    <science_support grid="f09_g17"/>
   </compset>
 
   <compset>
     <alias>BSSP245cmip6</alias>
     <lname>SSP245_CAM60_CLM50%BGC-CROP-CMIP6DECK_CICE%CMIP6_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
-    <science_support grid="f09_g17_gl4"/>
-    <science_support grid="f09_g17"/>
   </compset>
 
   <compset>
     <alias>BSSP370cmip6</alias>
     <lname>SSP370_CAM60_CLM50%BGC-CROP-CMIP6DECK_CICE%CMIP6_POP2%ECO%ABIO-DIC_MOSART_CISM2%NOEVOLVE_WW3_BGC%BDRD</lname>
-    <science_support grid="f09_g17_gl4"/>
-    <science_support grid="f09_g17"/>
   </compset>
 
   <!-- NorESM compset -->
@@ -276,16 +244,12 @@
     <!--lname>1850_CAM60%PTAERO_CLM50%BGC-CROP_CICE_BLOM_MOSART_SGLC_SWAV</lname -->
     <!-- lname>1850_CAM60%NORESM_CLM50%BGC-CROP_CICE_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname -->
     <lname>1850_CAM60%NORESM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f09_tn14"/>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <!-- uses differently organized emission files : FRC2 -->
   <compset>
     <alias>N1850frc2</alias>
     <lname>1850_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f09_tn14"/>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
@@ -296,122 +260,96 @@
   <compset>
     <alias>N1850esm</alias>
     <lname>1850_CAM60%NORESM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BPRPDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <!-- uses differently organized emission files : FRC2 -->
   <compset>
     <alias>N1850frc2esm</alias>
     <lname>1850_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BPRPDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
    <compset>
     <alias>N2000</alias>
     <lname>2000_CAM60%NORESM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f09_tn14"/>
-    <science_support grid="f19_tn14"/>
   </compset>
 
    <compset>
     <alias>N2000frc2</alias>
     <lname>2000_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f09_tn14"/>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NHIST</alias>
     <lname>HIST_CAM60%NORESM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f09_tn14"/>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <!--uses differently organized emission files : FRC2 -->
   <compset>
     <alias>NHISTfrc2</alias>
     <lname>HIST_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f09_tn14"/>
-    <science_support grid="f19_tn14"/>
   </compset>
 
    <compset>
     <alias>NHISTesm</alias>
     <lname>HIST_CAM60%NORESM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BPRPDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <!--uses differently organized emission files : FRC2 -->
   <compset>
     <alias>NHISTfrc2esm</alias>
     <lname>HIST_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BPRPDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NHISTpintcf</alias>
     <lname>HIST_CAM60%NORESM%PINTCF_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NHISTpiaer</alias>
     <lname>HIST_CAM60%NORESM%PIAER_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
  <compset>
     <alias>NHISTpiaeroxid</alias>
     <lname>HIST_CAM60%NORESM%PIAEROXID_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NCO2x4cmip6</alias>
     <lname>1850_CAM60%NORESM%4xCO2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f09_tn14"/>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <!-- uses differently organized emission files : FRC2 -->
   <compset>
     <alias>NCO2x4cmip6frc2</alias>
     <lname>1850_CAM60%NORESM%FRC2%4xCO2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f09_tn14"/>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>N1PCTcmip6</alias>
     <lname>1850_CAM60%NORESM%1PCT_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f09_tn14"/>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <!-- uses differently organized emission files : FRC2 -->
   <compset>
     <alias>N1PCTcmip6frc2</alias>
     <lname>1850_CAM60%NORESM%FRC2%1PCT_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f09_tn14"/>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>N1850ghgonly</alias>
     <lname>1850_CAM60%NORESM%GHGONLY_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>N1850natonly</alias>
     <lname>1850_CAM60%NORESM%NATONLY_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>N1850aeroxidonly</alias>
     <lname>1850_CAM60%NORESM%AEROXIDONLY_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <!-- NorESM scenarios -->
@@ -419,21 +357,16 @@
   <compset>
     <alias>NSSP126frc2</alias>
     <lname>SSP126_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f09_tn14"/>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP126frc2ext</alias>
     <lname>SSP126_CAM60%NORESM%FRC2EXT_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP245frc2</alias>
     <lname>SSP245_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f09_tn14"/>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
@@ -464,57 +397,46 @@
   <compset>
     <alias>NSSP370frc2</alias>
     <lname>SSP370_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f09_tn14"/>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP370LOWNTCFfrc2</alias>
     <lname>SSP370LOWNTCF_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP370REFGHGLOWNTCFfrc2</alias>
     <lname>SSP370REFGHGLOWNTCF_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP585frc2</alias>
     <lname>SSP585_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f09_tn14"/>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP585frc2ext</alias>
     <lname>SSP585_CAM60%NORESM%FRC2EXT_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP585frc2esm</alias>
     <lname>SSP585_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BPRPDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP534frc2</alias>
     <lname>SSP534_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP534frc2ext</alias>
     <lname>SSP534_CAM60%NORESM%FRC2EXT_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP534frc2esm</alias>
     <lname>SSP534_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BPRPDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <!-- Keyclim compsets with CISM -->
@@ -552,19 +474,16 @@
   <compset>
     <alias>NSSP245frc2ghgonly</alias>
     <lname>1850_CAM60%NORESM%GHGONLY%SSP245%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP245frc2natonly</alias>
     <lname>1850_CAM60%NORESM%NATONLY%SSP245%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>
     <alias>NSSP245frc2aeroxidonly</alias>
     <lname>1850_CAM60%NORESM%AEROXIDONLY%SSP245%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
-    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -524,11 +524,6 @@
   </compset>
 
   <compset>
-    <alias>N1850CwWs</alias>
-    <lname>1850_CAM60%WTSM_CLM50%BGC_CICE_BLOM_MOSART_SGLC_SWAV</lname>
-  </compset>
-
-  <compset>
     <alias>N1850C5L45BGCR</alias>
     <lname>1850_CAM50_CLM45%BGC_CICE_BLOM_RTM_SGLC_SWAV</lname>
   </compset>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -227,22 +227,19 @@
 
     	There are two types of compsets for NorESM2 : the (i) ones without "frc2", and (ii) the ones with "frc2" in their name.
 	These compsets differ slightly in how atmospheric emission files are organized (but in a climatological sense they are very close).
-	The "frc2" compset have been introduced to avoid a problem of non-reproducibility on the fram HPC.  
+	The "frc2" compset have been introduced to avoid a problem of non-reproducibility on the fram HPC.
 	The problem was that identical simulations setup without "frc2" started to divergence on average after 5 to 8 years into the simulations.i
 	With "frc2", we do not have that problem on fram HPC anaymore.
 
 	For the CMIP6 simulations submitted to ESGF, some have been done without "frc2", some with "frc2".
 	As a general rule :
 	(i) f09 resolution : all simulations have been done WITH frc2.
-	(ii) f19 resolution : 
+	(ii) f19 resolution :
        		piControl + historical + perturbed historical (hist-aer, hist-GHG, hist-nat) have been done WITHOUT frc2
 		scenarios + perturbed scenarions : have been done WITH frc2 -->
 
   <compset>
     <alias>N1850</alias>
-    <!--lname>1850_CAM60%PTAERO_CLM50%BGC_CICE_BLOM_MOSART_SGLC_SWAV</lname-->
-    <!--lname>1850_CAM60%PTAERO_CLM50%BGC-CROP_CICE_BLOM_MOSART_SGLC_SWAV</lname -->
-    <!-- lname>1850_CAM60%NORESM_CLM50%BGC-CROP_CICE_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname -->
     <lname>1850_CAM60%NORESM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
   </compset>
 
@@ -488,42 +485,42 @@
 
   <compset>
     <alias>N1850OC</alias>
-    <lname>1850_CAM60%PTAERO_CLM50%BGC_CICE_BLOM%ECO_MOSART_SGLC_SWAV</lname>
+    <lname>1850_CAM60%NORESM_CLM50%BGC_CICE_BLOM%ECO_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>N1850OCBPRP</alias>
-    <lname>1850_CAM60%PTAERO_CLM50%BGC_CICE_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BPRP</lname>
+    <lname>1850_CAM60%NORESM_CLM50%BGC_CICE_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BPRP</lname>
   </compset>
 
   <compset>
     <alias>N1850OCBPRPDMS</alias>
-    <lname>1850_CAM60%PTAERO_CLM50%BGC_CICE_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BPRPDMS</lname>
+    <lname>1850_CAM60%NORESM_CLM50%BGC_CICE_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BPRPDMS</lname>
   </compset>
 
   <compset>
     <alias>N1850OCBDRDDMS</alias>
-    <lname>1850_CAM60%PTAERO_CLM50%BGC-CROP_CICE_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <lname>1850_CAM60%NORESM_CLM50%BGC-CROP_CICE_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
   </compset>
 
   <compset>
     <alias>NHISTOCBDRDDMS</alias>
-    <lname>HIST_CAM60%PTAERO_CLM50%BGC-CROP_CICE_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <lname>HIST_CAM60%NORESM_CLM50%BGC-CROP_CICE_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
   </compset>
 
   <compset>
     <alias>N1850OCDMS</alias>
-    <lname>1850_CAM60%PTAERO_CLM50%BGC_CICE_BLOM%ECO_MOSART_SGLC_SWAV_BGC%DMS</lname>
+    <lname>1850_CAM60%NORESM_CLM50%BGC_CICE_BLOM%ECO_MOSART_SGLC_SWAV_BGC%DMS</lname>
   </compset>
 
   <compset>
     <alias>N1850P</alias>
-    <lname>1850_CAM60%PTAERO_CLM50%BGC_CICE_POP2_MOSART_SGLC_SWAV</lname>
+    <lname>1850_CAM60%NORESM_CLM50%BGC_CICE_POP2_MOSART_SGLC_SWAV</lname>
   </compset>
 
   <compset>
     <alias>N1850G</alias>
-    <lname>1850_CAM60%PTAERO_CLM50%BGC-CROP_CICE_BLOM_MOSART_CISM2%EVOLVE_SWAV</lname>
+    <lname>1850_CAM60%NORESM_CLM50%BGC-CROP_CICE_BLOM_MOSART_CISM2%EVOLVE_SWAV</lname>
   </compset>
 
   <compset>

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -3,7 +3,7 @@
 
   <test name="ERS_Ld5" grid="f09_tn14" compset="N1850frc2" testmods="allactive/defaultio">
     <machines>
-      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
@@ -11,7 +11,7 @@
   </test>
   <test name="SMS_D_Ld1" grid="f09_tn14" compset="N1850frc2" testmods="allactive/defaultio">
     <machines>
-      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
@@ -19,7 +19,7 @@
   </test>
   <test name="PFS" grid="f09_tn14" compset="N1850frc2" testmods="allactive/defaultio">
     <machines>
-      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
@@ -27,7 +27,7 @@
   </test>
   <test name="ERS_Ld5" grid="f09_tn14" compset="NHISTfrc2" testmods="allactive/defaultio">
     <machines>
-      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
@@ -35,7 +35,7 @@
   </test>
   <test name="SMS_D_Ld1" grid="f09_tn14" compset="NHISTfrc2" testmods="allactive/defaultio">
     <machines>
-      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
@@ -43,7 +43,7 @@
   </test>
   <test name="PFS" grid="f09_tn14" compset="NHISTfrc2" testmods="allactive/defaultio">
     <machines>
-      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
@@ -52,7 +52,7 @@
 
   <test name="ERS_Ld5" grid="f19_tn14" compset="N1850" testmods="allactive/defaultio">
     <machines>
-      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
@@ -60,7 +60,7 @@
   </test>
   <test name="SMS_D_Ld1" grid="f19_tn14" compset="N1850" testmods="allactive/defaultio">
     <machines>
-      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
@@ -68,7 +68,7 @@
   </test>
   <test name="PFS" grid="f19_tn14" compset="N1850">
     <machines>
-      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
@@ -76,7 +76,7 @@
   </test>
   <test name="ERS_Ld5" grid="f19_tn14" compset="NHIST" testmods="allactive/defaultio">
     <machines>
-      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
@@ -84,7 +84,7 @@
   </test>
   <test name="SMS_D_Ld1" grid="f19_tn14" compset="NHIST" testmods="allactive/defaultio">
     <machines>
-      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
@@ -92,7 +92,7 @@
   </test>
   <test name="PFS" grid="f19_tn14" compset="NHIST">
     <machines>
-      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
@@ -101,7 +101,7 @@
 
   <test name="ERS_Ld5" grid="f19_tn14" compset="N1850esm" testmods="allactive/defaultio">
     <machines>
-      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
@@ -109,7 +109,7 @@
   </test>
   <test name="SMS_D_Ld1" grid="f19_tn14" compset="N1850esm" testmods="allactive/defaultio">
     <machines>
-      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
@@ -117,7 +117,7 @@
   </test>
   <test name="PFS" grid="f19_tn14" compset="N1850esm">
     <machines>
-      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>


### PR DESCRIPTION
The two major updates in this PR are:

1. Correct errors in config_compsets.xml and testlist_allactive.xml
2. Update externals with NorESM2.1 updates

The details:
- #483 (Update CIME tag). See PR NorESMhub/cime#65
- #484 (Remove science support for coupled compset / resolution combinations). This PR
- #487 (Remove PTAERO from config_compsets.xml). This and other errors (e.g., removal of an invalid compset) are corrected in this PR
- #491 (Update BLOM tag). See PR NorESMhub/BLOM#321

Closes #483 
Closes #484 
Closes #487
Closes #491