### PR TITLE
release-noresm2.1.0a3: Update CIME external with Python fix

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -13,7 +13,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_NorESM2_1_r3
+tag = cime5.6.10_NorESM2_1_r4
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime


### PR DESCRIPTION
Update CIME external with new tag that attempts to ensure that the CIME CCS always has access to a valid version of Python by loading it as a module inside the case.

closes #493 