### PR TITLE
release-noresm2.1.0: Update CAM tag

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [cam]
-tag = cam_noresm2_1_v1.0.1
+tag = cam_noresm2_1_v1.0.2
 protocol = git
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam


### PR DESCRIPTION
Update CAM tag to cam_noresm2_1_v1.0.2 to capture the latest CAM change NorESMhub/CAM#125.

This does change answers due to bug fixes.
The `prealpha_noresm` test suite was run.
New baselines are in /cluster/shared/noresm/noresm_baselines/release-noresm2.1.0 on Betzy.