### PR TITLE
Remove preprocessorDefinitions.h files

### DIFF
--- a/cime_config/usermods_dirs/cmip6_noresm_DECK/SourceMods/src.cam/preprocessorDefinitions.h
+++ b/cime_config/usermods_dirs/cmip6_noresm_DECK/SourceMods/src.cam/preprocessorDefinitions.h
@@ -1,2 +1,0 @@
-#undef AEROCOM
-#define AEROFFL

--- a/cime_config/usermods_dirs/cmip6_noresm_hifreq/SourceMods/src.cam/preprocessorDefinitions.h
+++ b/cime_config/usermods_dirs/cmip6_noresm_hifreq/SourceMods/src.cam/preprocessorDefinitions.h
@@ -1,2 +1,0 @@
-#undef AEROCOM
-#define AEROFFL

--- a/cime_config/usermods_dirs/cmip6_noresm_hifreq_xaer/SourceMods/src.cam/preprocessorDefinitions.h
+++ b/cime_config/usermods_dirs/cmip6_noresm_hifreq_xaer/SourceMods/src.cam/preprocessorDefinitions.h
@@ -1,2 +1,0 @@
-#define AEROCOM
-#define AEROFFL

--- a/cime_config/usermods_dirs/cmip6_noresm_hifreq_xaer/shell_commands
+++ b/cime_config/usermods_dirs/cmip6_noresm_hifreq_xaer/shell_commands
@@ -1,0 +1,2 @@
+# Turn on AEROCOM diagnostic output
+./xmlchange AEROCOM=TRUE

--- a/cime_config/usermods_dirs/cmip6_noresm_hifreq_xaer/shell_commands
+++ b/cime_config/usermods_dirs/cmip6_noresm_hifreq_xaer/shell_commands
@@ -1,2 +1,2 @@
 # Turn on AEROCOM diagnostic output
-./xmlchange AEROCOM=TRUE
+./xmlchange CAM_AEROCOM=TRUE

--- a/cime_config/usermods_dirs/cmip6_noresm_keyCLIM/SourceMods/src.cam/preprocessorDefinitions.h
+++ b/cime_config/usermods_dirs/cmip6_noresm_keyCLIM/SourceMods/src.cam/preprocessorDefinitions.h
@@ -1,2 +1,0 @@
-#undef AEROCOM
-#define AEROFFL

--- a/cime_config/usermods_dirs/cmip6_noresm_keyCLIM_ism/SourceMods/src.cam/preprocessorDefinitions.h
+++ b/cime_config/usermods_dirs/cmip6_noresm_keyCLIM_ism/SourceMods/src.cam/preprocessorDefinitions.h
@@ -1,2 +1,0 @@
-#undef AEROCOM
-#define AEROFFL

--- a/cime_config/usermods_dirs/cmip6_noresm_xaer/SourceMods/src.cam/preprocessorDefinitions.h
+++ b/cime_config/usermods_dirs/cmip6_noresm_xaer/SourceMods/src.cam/preprocessorDefinitions.h
@@ -1,2 +1,0 @@
-#define AEROCOM
-#define AEROFFL

--- a/cime_config/usermods_dirs/cmip6_noresm_xaer/shell_commands
+++ b/cime_config/usermods_dirs/cmip6_noresm_xaer/shell_commands
@@ -1,0 +1,2 @@
+# Turn on AEROCOM diagnostic output
+./xmlchange AEROCOM=TRUE

--- a/cime_config/usermods_dirs/cmip6_noresm_xaer/shell_commands
+++ b/cime_config/usermods_dirs/cmip6_noresm_xaer/shell_commands
@@ -1,2 +1,2 @@
 # Turn on AEROCOM diagnostic output
-./xmlchange AEROCOM=TRUE
+./xmlchange CAM_AEROCOM=TRUE


### PR DESCRIPTION
preprocessor files such as preprocessorDefinitions.h should not be used.
These files have been removed (there were all in cime_config/usermods_dirs).
Where the preprocessorDefinitions.h file defined the AEROCOM preprocessor symbol, this behavior was restored by adding `./xmlchange AEROCOM=TRUE` to a shell_commands file in the same usermod.

Run tests to see if these compsets build sucessfully?