### PR TITLE
Revert "Update CIME and CTSM tags to be able to run on Betzy"

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -14,7 +14,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_NorESM2_1_r4
+tag = cime5.6.10_NorESM2_3_r2
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime
@@ -29,7 +29,7 @@ externals = Externals_CISM.cfg
 required = False
 
 [clm]
-tag = release-clm5.0.14-Nor_v1.0.5
+tag = release-clm5.0.14-Nor_v1.0.7
 protocol = git
 repo_url = https://github.com/NorESMhub/ctsm
 local_path = components/clm

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -14,7 +14,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_NorESM2_3_r1
+tag = cime5.6.10_NorESM2_1_r4
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime
@@ -29,7 +29,7 @@ externals = Externals_CISM.cfg
 required = False
 
 [clm]
-tag = release-clm5.0.14-Nor_v1.0.6
+tag = release-clm5.0.14-Nor_v1.0.5
 protocol = git
 repo_url = https://github.com/NorESMhub/ctsm
 local_path = components/clm


### PR DESCRIPTION
Externals update due to fixed LMOD cache failure on betzy.
