### PR TITLE
Redefine NHIST and N1850 to use Cloud2 tunings

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [cam]
-branch = noresm2_3_develop
+tag = cam_noresm2_3_v1.0.0a
 protocol = git
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -412,6 +412,11 @@
   </compset>
 
   <compset>
+    <alias>NSSP585cloud2</alias>
+    <lname>SSP585_CAM60%NORESM%FRC2%CLOUD2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+  </compset>
+
+  <compset>
     <alias>NSSP585frc2ext</alias>
     <lname>SSP585_CAM60%NORESM%FRC2EXT_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
   </compset>

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
 
+  <test name="SMS_D_Ld5" grid="f09_tn14" compset="NSSP585cloud2" testmods="allactive/defaultio">
+    <machines>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00 </option>
+    </options>
+  </test>
   <test name="ERS_Ld5" grid="f09_tn14" compset="N1850frc2" testmods="allactive/defaultio">
     <machines>
       <machine name="betzy" compiler="intel" category="prealpha_noresm"/>

--- a/describe_version
+++ b/describe_version
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Describes the NorESM version and any local modifications
+Original from ESCOMP/CESM"""
+
+import os
+import argparse
+import subprocess
+
+def commandline_args():
+    """Parse and return command-line arguments
+    """
+
+    # We don't really need an argument parser, since there currently aren't any
+    # arguments. But providing this allows supporting a '--help' option with a
+    # description.
+
+    description = """
+Script for describing the CESM version and any local modifications
+
+Simply run:
+
+    ./describe_version
+
+without any arguments.
+
+You may want to redirect the output to a file, such as:
+
+    ./describe_version > current_version.txt
+"""
+
+    parser = argparse.ArgumentParser(
+        description=description,
+        formatter_class=argparse.RawTextHelpFormatter)
+
+    args = parser.parse_args()
+    return args
+
+def main():
+    """Main function for describe_version"""
+    # We currently don't actually need any arguments, but call this to allow '--help' usage
+    _ = commandline_args()
+
+    # Allow this script to run correctly even if invoked from some other directory; note that
+    # we assume that the script resides in the top level of the CESM checkout.
+    cesmroot = os.path.dirname(os.path.realpath(__file__))
+
+    separator = 72*'-' + '\n'
+
+    # The '--long' option to git describe forces it to always show the hash, even if we're
+    # on a tag.
+    git_describe = subprocess.check_output(['git', 'describe', '--long'],
+                                           cwd=cesmroot,
+                                           universal_newlines=True)
+    print(separator + 'git describe:\n' + git_describe + separator)
+
+    git_status = subprocess.check_output(['git', 'status'],
+                                         cwd=cesmroot,
+                                         universal_newlines=True)
+    print(separator + 'git status:\n' + git_status + separator)
+
+    manic = os.path.join('manage_externals', 'checkout_externals')
+    # Give '--verbose' twice to give very verbose output, showing all modified files in
+    # each external.
+    manage_externals_status = subprocess.check_output([manic, '--status', '--verbose', '--verbose'],
+                                                      cwd=cesmroot,
+                                                      universal_newlines=True)
+    print(separator + 'manage_externals status:\n' + manage_externals_status + separator)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The KeyClim Cloud2 tunings are now the default for NHIST and N1850 compsets

- Added compset and test to reproduce the Cloud2 experiment
- Add namelist definitions, defaults and exceptions for clubb_meltpt_temp and clubb_dt_low
- Modify WBF effective factor for keyClim
- Update CAM external tag
- Added a top-level script, `describe_version` (taken from CESM), which documents the current code configuration.