### PR TITLE
Remove the docs submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "docs"]
-	path = docs
-	url = https://github.com/NorESMhub/NorESM-docs.git
-	branch = noresm2


### PR DESCRIPTION
We used to have the docs integrated with the source code. When we moved the documentation to a new repository, I thought we could keep a remnant of the old structure by including the relevant docs branch as a submodule. However, as we are building now documentation pages from the `noresm-docs` repository, this submodule structure probably does  not serve any purpose anymore. I therefore suggest to remove it as not to include unnecessary dependencies in the repository. 