### PR TITLE
noresm2_3_develop : Introduction of possibility to run with full atmospheric chemistry

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,7 +1,7 @@
 [cam]
 branch = noresm2_3_chem
 protocol = git
-repo_url = https://github.com/DirkOlivie/CAM
+repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg
 required = True

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [cam]
-branch = cam_noresm2_3_v1.0.0b
+tag = cam_noresm2_3_v1.0.0b
 protocol = git
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,7 +1,7 @@
 [cam]
-branch = noresm2_3_develop
+branch = noresm2_3_chem
 protocol = git
-repo_url = https://github.com/NorESMhub/CAM
+repo_url = https://github.com/DirkOlivie/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg
 required = True

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,7 +1,7 @@
 [cam]
 branch = noresm2_3_chem
 protocol = git
-repo_url = https://github.com/NorESMhub/CAM
+repo_url = https://github.com/DirkOlivie/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg
 required = True

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,7 +1,7 @@
 [cam]
-branch = noresm2_3_chem
+branch = cam_noresm2_3_v1.0.0b
 protocol = git
-repo_url = https://github.com/DirkOlivie/CAM
+repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg
 required = True

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -243,6 +243,12 @@
     <lname>1850_CAM60%NORESM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
   </compset>
 
+  <compset>
+    <alias>N1850_tropstratchem</alias>
+    <lname>1850_CAM60%NORESM%TROPSTRATCHEM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f09_tn14"/>
+    <science_support grid="f19_tn14"/>
+  </compset>
   <!-- uses differently organized emission files : FRC2 -->
   <compset>
     <alias>N1850frc2</alias>
@@ -278,6 +284,13 @@
   <compset>
     <alias>NHIST</alias>
     <lname>HIST_CAM60%NORESM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+  </compset>
+
+  <compset>
+    <alias>NHIST_tropstratchem</alias>
+    <lname>HIST_CAM60%NORESM%TROPSTRATCHEM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f09_tn14"/>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <!--uses differently organized emission files : FRC2 -->
@@ -392,6 +405,13 @@
   </compset>
 
   <compset>
+    <alias>NSSP370_tropstratchem</alias>
+    <lname>SSP370_CAM60%NORESM%TROPSTRATCHEM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f09_tn14"/>
+    <science_support grid="f19_tn14"/>
+  </compset>
+
+  <compset>
     <alias>NSSP370frc2</alias>
     <lname>SSP370_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
   </compset>
@@ -404,6 +424,13 @@
   <compset>
     <alias>NSSP370REFGHGLOWNTCFfrc2</alias>
     <lname>SSP370REFGHGLOWNTCF_CAM60%NORESM%FRC2_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+  </compset>
+
+  <compset>
+    <alias>NSSP585_tropstratchem</alias>
+    <lname>SSP585_CAM60%NORESM%TROPSTRATCHEM_CLM50%BGC-CROP_CICE%NORESM-CMIP6_BLOM%ECO_MOSART_SGLC_SWAV_BGC%BDRDDMS</lname>
+    <science_support grid="f09_tn14"/>
+    <science_support grid="f19_tn14"/>
   </compset>
 
   <compset>

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -49,7 +49,15 @@
       <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-
+  <test name="ERS_Ld5" grid="f09_tn14" compset="NHIST_tropstratchem" testmods="allactive/defaultio">
+    <machines>
+      <machine name="betzy" compiler="intel" category="prealpha_noresm"/>
+    </machines>
+    <options>
+      <option name="comment">Test full chemistry compset</option>
+      <option name="wallclock"> 01:00 </option>
+    </options>
+  </test>
   <test name="ERS_Ld5" grid="f19_tn14" compset="N1850" testmods="allactive/defaultio">
     <machines>
       <machine name="betzy" compiler="intel" category="prealpha_noresm"/>


### PR DESCRIPTION
General :
Introduction of the ability to run with more complex atmospheric gas-phase chemistry. This PR goes together with a separate PR for OSLO_AERO and one for CAM

The changes are only :
cime_config/config_compsets.xml : new compsets for running the new chemistry scheme have been added