### PR TITLE
Update Externals.cfg - BLOM v1.6.0

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -51,7 +51,7 @@ required = True
 
 [blom]
 protocol = git
-tag = dev1.5.1.4
+tag = v1.6.0
 repo_url = https://github.com/NorESMHub/BLOM
 local_path = components/blom
 externals = Externals_BLOM.cfg


### PR DESCRIPTION
Update BLOM version to latest release - `v1.6.0`.
Not sure how often we should update the `Externals.cfg`. I think it could make sense for `v1.6.0` since this will be the NorESM2.3 version, but we could also wait until after refactorization of BLOM.