### PR TITLE
noresm2_5_alpha03: Component updates

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -59,8 +59,8 @@ required = True
 
 [cam]
 protocol = git
-tag = noresm_v12_cam6_3_123
-repo_url = https://github.com/NorESMhub/CAM
+branch = gold2718/UpdateNoresmBranch
+repo_url = https://github.com/mvertens/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg
 required = True
@@ -75,30 +75,30 @@ required = True
 
 [cdeps]
 protocol = git
-tag = cdeps1.0.33_noresm_v0
-repo_url = https://github.com/NorESMhub/CDEPS.git
+tag = cdeps1.0.36
+repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps
 externals =  Externals_CDEPS.cfg
 required = True
 
 [cmeps]
 protocol = git
-tag = cmeps0.14.60_noresm_v0
-repo_url = https://github.com/NorESMhub/CMEPS.git
+branch = feature/trigrid
+repo_url = https://github.com/mvertens/CMEPS.git
 local_path = components/cmeps
 required = True
 
 [cism]
 protocol = git
-tag = cismwrap_2_1_99_noresm_v1
-repo_url = https://github.com/NorESMhub/CISM-wrapper
+branch = feature/cism2mosart
+repo_url = https://github.com/mvertens/CISM-wrapper
 local_path = components/cism
 externals = Externals_CISM.cfg
 required = True
 
 [clm]
 protocol = git
-tag = ctsm5.2.0-noresm_v0
+tag = ctsm5.2.005-noresm_v1
 repo_url = https://github.com/NorESMhub/CTSM
 local_path = components/clm
 externals = Externals_CLM.cfg
@@ -106,8 +106,8 @@ required = True
 
 [mosart]
 protocol = git
-tag = mosart1_0_49_noresm_v2
-repo_url = https://github.com/NorESMhub/MOSART
+branch = feature/cism2mosart
+repo_url = https://github.com/mvertens/MOSART
 local_path = components/mosart
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -23,7 +23,7 @@ required = True
 [ccs_config]
 protocol = git
 #branch = feature/trigrid
-tag = 7adbb95
+tag = 44838ea
 repo_url = https://github.com/mvertens/ccs_config_cesm.git
 local_path = ccs_config
 required = True
@@ -58,8 +58,7 @@ protocol = git
 # https://github.com/NorESMhub/BLOM
 # branch = feature/ocn2glc
 tag = 586a758
-repo_url = https://github.com/mvertens/CAM
-branch = feature/ocn2glc
+repo_url = https://github.com/mvertens/BLOM
 local_path = components/blom
 externals = Externals_BLOM.cfg
 required = True

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -106,8 +106,8 @@ required = True
 
 [mosart]
 protocol = git
-branch = feature/cism2mosart
-repo_url = https://github.com/mvertens/MOSART
+tag = mosart1.1.02
+repo_url = https://github.com/ESCOMP/MOSART
 local_path = components/mosart
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -22,18 +22,15 @@ required = True
 
 [ccs_config]
 protocol = git
-#branch = feature/trigrid
-tag = 44838ea
-repo_url = https://github.com/mvertens/ccs_config_cesm.git
+tag = ccs_config_noresm0.0.31
+repo_url = https://github.com/NorESMhub/ccs_config_noresm.git
 local_path = ccs_config
 required = True
 
 [cime]
 protocol = git
-branch = feature/fix_cprnc
-repo_url = https://github.com/mvertens/cime.git
-#tag = cime6.0.250
-#repo_url = https://github.com/ESMCI/cime.git
+tag = cime6.0.250_noresm_v0
+repo_url = https://github.com/NorESMhub/cime.git
 local_path = cime
 required = True
 
@@ -54,9 +51,7 @@ required = True
 
 [blom]
 protocol = git
-# tag = dev1.6.1.3
-# https://github.com/NorESMhub/BLOM
-# branch = feature/ocn2glc
+#branch = feature/ocn2glc (one off from dev1.6.1.3)
 tag = 586a758
 repo_url = https://github.com/mvertens/BLOM
 local_path = components/blom
@@ -66,7 +61,7 @@ required = True
 [cam]
 protocol = git
 #branch = feature/UpdateNoresmBranch
-tag = feature/UpdateNoresmBranch
+tag = 8d0ea5ee
 repo_url = https://github.com/mvertens/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg
@@ -91,7 +86,7 @@ required = True
 [cmeps]
 protocol = git
 #branch = feature/add_blom
-tag = 5bf3de09
+tag = 38622180
 repo_url = https://github.com/mvertens/CMEPS.git
 local_path = components/cmeps
 required = True

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -54,9 +54,12 @@ required = True
 
 [blom]
 protocol = git
-#tag = dev1.6.1.2
-branch = feature/fixbugs
-repo_url = https://github.com/mvertens/BLOM
+# tag = dev1.6.1.3
+# https://github.com/NorESMhub/BLOM
+# branch = feature/ocn2glc
+tag = 586a758
+repo_url = https://github.com/mvertens/CAM
+branch = feature/ocn2glc
 local_path = components/blom
 externals = Externals_BLOM.cfg
 required = True
@@ -89,7 +92,7 @@ required = True
 [cmeps]
 protocol = git
 #branch = feature/add_blom
-tag = ee184f74
+tag = 5bf3de09
 repo_url = https://github.com/mvertens/CMEPS.git
 local_path = components/cmeps
 required = True

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -51,7 +51,7 @@ required = True
 
 [blom]
 protocol = git
-tag = dev1.5.1.4
+tag = v1.6.1
 repo_url = https://github.com/NorESMHub/BLOM
 local_path = components/blom
 externals = Externals_BLOM.cfg
@@ -59,7 +59,7 @@ required = True
 
 [cam]
 protocol = git
-branch = gold2718/UpdateNoresmBranch
+branch = feature/UpdateNoresmBranch
 repo_url = https://github.com/mvertens/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -51,8 +51,10 @@ required = True
 
 [blom]
 protocol = git
-tag = v1.6.1
-repo_url = https://github.com/NorESMHub/BLOM
+#tag = v1.6.1
+#repo_url = https://github.com/NorESMHub/BLOM
+branch = feature/refactor_blom
+repo_url = https://github.com/mvertens/BLOM
 local_path = components/blom
 externals = Externals_BLOM.cfg
 required = True

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -44,7 +44,7 @@ required = True
 [share]
 protocol = git
 branch = feature/update_share
-repo_url = https://github.com/mvertens/NorESM_share
+repo_url = https://github.com/mvertens/CESM_share
 local_path = share
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -77,8 +77,9 @@ required = True
 
 [cdeps]
 protocol = git
-tag = cdeps1.0.43
-repo_url = https://github.com/ESCOMP/CDEPS.git
+#branch = feature/add_dom_to_multilevtag (one off from cdeps1.0.43)
+tag = d0e8fc7
+repo_url = https://github.com/mvertens/CDEPS.git
 local_path = components/cdeps
 externals =  Externals_CDEPS.cfg
 required = True

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -42,8 +42,9 @@ required = True
 [share]
 protocol = git
 #branch = feature/update_share
-tag = 870f7a2
-repo_url = https://github.com/mvertens/NorESM_share
+#repo_url = https://github.com/mvertens/NorESM_share
+tag = share1.1.2
+repo_url = https://github.com/ESCOMP/CESM_share
 local_path = share
 required = True
 
@@ -53,8 +54,9 @@ required = True
 
 [blom]
 protocol = git
-tag = dev1.6.1.2
-repo_url = https://github.com/NorESMhub/BLOM
+#tag = dev1.6.1.2
+branch = feature/fixbugs
+repo_url = https://github.com/mvertens/BLOM
 local_path = components/blom
 externals = Externals_BLOM.cfg
 required = True
@@ -62,7 +64,7 @@ required = True
 [cam]
 protocol = git
 #branch = feature/UpdateNoresmBranch
-tag = 31d580aa
+tag = c1b868a5
 repo_url = https://github.com/mvertens/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -22,14 +22,15 @@ required = True
 
 [ccs_config]
 protocol = git
-tag = ccs_config_noresm0.0.30
-repo_url = https://github.com/NorESMhub/ccs_config_noresm.git
+#branch = feature/trigrid
+tag = 7adbb95
+repo_url = https://github.com/mvertens/ccs_config_cesm.git
 local_path = ccs_config
 required = True
 
 [cime]
 protocol = git
-branch = cime6.0.238_httpsbranch
+tag = cime6.0.250
 repo_url = https://github.com/ESMCI/cime.git
 local_path = cime
 required = True
@@ -40,8 +41,9 @@ required = True
 
 [share]
 protocol = git
-tag = share1.0.18_noresm_v0
-repo_url = https://github.com/NorESMhub/NorESM_share
+#branch = feature/update_share
+tag = 870f7a2
+repo_url = https://github.com/mvertens/NorESM_share
 local_path = share
 required = True
 
@@ -51,17 +53,16 @@ required = True
 
 [blom]
 protocol = git
-#tag = v1.6.1
-#repo_url = https://github.com/NorESMHub/BLOM
-branch = feature/refactor_blom
-repo_url = https://github.com/mvertens/BLOM
+tag = dev1.6.1.2
+repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom
 externals = Externals_BLOM.cfg
 required = True
 
 [cam]
 protocol = git
-branch = feature/UpdateNoresmBranch
+#branch = feature/UpdateNoresmBranch
+tag = 31d580aa
 repo_url = https://github.com/mvertens/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg
@@ -85,14 +86,16 @@ required = True
 
 [cmeps]
 protocol = git
-branch = feature/trigrid
+#branch = feature/dms_and_bromo
+tag = 9598a494
 repo_url = https://github.com/mvertens/CMEPS.git
 local_path = components/cmeps
 required = True
 
 [cism]
 protocol = git
-branch = feature/cism2mosart
+#branch = feature/cism2mosart
+tag = 756cfa6
 repo_url = https://github.com/mvertens/CISM-wrapper
 local_path = components/cism
 externals = Externals_CISM.cfg

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -30,8 +30,10 @@ required = True
 
 [cime]
 protocol = git
-tag = cime6.0.250
-repo_url = https://github.com/ESMCI/cime.git
+branch = feature/fix_cprnc
+repo_url = https://github.com/mvertens/cime.git
+#tag = cime6.0.250
+#repo_url = https://github.com/ESMCI/cime.git
 local_path = cime
 required = True
 
@@ -41,10 +43,8 @@ required = True
 
 [share]
 protocol = git
-#branch = feature/update_share
-#repo_url = https://github.com/mvertens/NorESM_share
-tag = share1.1.2
-repo_url = https://github.com/ESCOMP/CESM_share
+branch = feature/update_share
+repo_url = https://github.com/mvertens/NorESM_share
 local_path = share
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -64,7 +64,7 @@ required = True
 [cam]
 protocol = git
 #branch = feature/UpdateNoresmBranch
-tag = c1b868a5
+tag = feature/UpdateNoresmBranch
 repo_url = https://github.com/mvertens/CAM
 local_path = components/cam
 externals = Externals_CAM.cfg
@@ -80,7 +80,7 @@ required = True
 
 [cdeps]
 protocol = git
-tag = cdeps1.0.36
+tag = cdeps1.0.43
 repo_url = https://github.com/ESCOMP/CDEPS.git
 local_path = components/cdeps
 externals =  Externals_CDEPS.cfg
@@ -88,16 +88,16 @@ required = True
 
 [cmeps]
 protocol = git
-#branch = feature/dms_and_bromo
-tag = 9598a494
+#branch = feature/add_blom
+tag = ee184f74
 repo_url = https://github.com/mvertens/CMEPS.git
 local_path = components/cmeps
 required = True
 
 [cism]
 protocol = git
-#branch = feature/cism2mosart
-tag = 756cfa6
+#branch = feature/cism_coupling_to_ocn
+tag = 5df18f4e
 repo_url = https://github.com/mvertens/CISM-wrapper
 local_path = components/cism
 externals = Externals_CISM.cfg

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -36,33 +36,20 @@
     - grid  (optional regular expression match for grid to work with the compset)
   </help>
 
-  <!-- 1850 compsets Default, Mosart, Wave for CESM2 -->
+  <!-- 1850 compset -->
 
   <compset>
-    <alias>B1850</alias>
-    <lname>1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%GRIS-NOEVOLVE_WW3_BGC%BDRD</lname>
+    <alias>N1850</alias>
+    <lname>1850_CAM%DEV%LT%NORESM%CAMoslo_CLM51%SP_CICE_BLOM%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
   </compset>
 
   <compset>
-    <alias>BW1850</alias>
-    <lname>1850_CAM60%WCTS_CLM50%BGC-CROP_CICE_POP2%ECO%NDEP_MOSART_CISM2%GRIS-NOEVOLVE_WW3</lname>
-  </compset>
-  <compset>
-    <alias>BWma1850</alias>
-    <lname>1850_CAM60%WCCM_CLM50%BGC-CROP_CICE_POP2%ECO%NDEP_MOSART_CISM2%GRIS-NOEVOLVE_WW3</lname>
-  </compset>
-
-  <compset>
-    <alias>BHIST</alias>
-    <lname>HIST_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%GRIS-NOEVOLVE_WW3_BGC%BDRD</lname>
+    <alias>N1850mam4</alias>
+    <lname>1850_CAM%DEV%LT%GHGMAM4_CLM51%SP_CICE_BLOM%ECO_MOSART_DGLC%NOEVOLVE_SWAV_SESP</lname>
   </compset>
 
   <!-- BG compsets: evolving ice sheet -->
 
-  <compset>
-    <alias>B1850G</alias>
-    <lname>1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_CISM2%GRIS-EVOLVE_WW3_BGC%BDRD</lname>
-  </compset>
 
   <!-- Prognostic wave -->
 
@@ -75,23 +62,7 @@
 
   <!-- SOM compsets -->
 
-  <compset>
-    <alias>ETEST</alias>
-    <lname>2000_CAM60_CLM50%SP_CICE_DOCN%SOM_MOSART_SGLC_SWAV_TEST</lname>
-  </compset>
-
-  <compset>
-    <alias>E1850TEST</alias>
-    <lname>1850_CAM60_CLM50%SP_CICE_DOCN%SOM_MOSART_SGLC_SWAV_TEST</lname>
-  </compset>
-
   <!-- fully coupled MOM6 runs -->
-  <compset>
-    <!-- MOM is an optional component of CESM and is not checked out by default
-	 use checkout_externals mom to add it -->
-    <alias>B1850MOM</alias>
-    <lname>1850_CAM60_CLM50%BGC-CROP_CICE_MOM6_MOSART_CISM2%GRIS-NOEVOLVE_SWAV_BGC%BDRD</lname>
-  </compset>
 
   <!-- All active except data atmosphere
        Used for spinup and testing of CISM couplings -->


### PR DESCRIPTION
This PR will be used in simulations appearing in https://github.com/NorESMhub/noresm_simulations/discussions/7.
Unfortunately, only minimal testing has been done on the various configurations since betzy has been down or unstable during a good part of late June and early July. However, a restart test have been carried out for ERS_Ld5.ne30pg3_f09_tn14.N1850.betzy_intel and restarts are passing.

Also - tags for CAM, CISM, BLOM and CMEPS point to branches on https://github.com/mvertens rather than https://github.com/NorESMhub. Those branches will not be deleted at this point and moving forwards PRs will be done to NorESMhub for the next noresm2_3_alpha04 tag.