### PR TITLE
Updates for noresm2.0.8

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -13,7 +13,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_cesm2_1_rel_06-Nor_v1.0.6
+tag = cime5.6.10_NorESM2_3_r3
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -13,7 +13,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_NorESM2_3_r3
+tag = cime5.6.10_NorESM2_3_r4
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime

--- a/cime_config/testlist_allactive.xml
+++ b/cime_config/testlist_allactive.xml
@@ -1,425 +1,127 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
-  <test name="ERI" grid="f09_g17" compset="B1850" testmods="allactive/defaultio_noclminterp">
+
+  <test name="ERS_Ld5" grid="f09_tn14" compset="N1850frc2" testmods="allactive/defaultio">
     <machines>
-      <machine name="bluewaters" compiler="pgi" category="prebeta"/>
+      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test name="ERI" grid="f09_g17" compset="B1850" testmods="allactive/defaultio_noclminterp">
+  <test name="SMS_D_Ld1" grid="f09_tn14" compset="N1850frc2" testmods="allactive/defaultio">
     <machines>
-      <machine name="edison" compiler="intel" category="prebeta"/>
+      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test name="ERI" grid="f09_g17" compset="B1850" testmods="allactive/defaultio_noclminterp">
+  <test name="PFS" grid="f09_tn14" compset="N1850frc2" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test name="SMS_Ld2" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
+  <test name="ERS_Ld5" grid="f09_tn14" compset="NHISTfrc2" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cime_baselines"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="SMS_N3_PM3_Ld2" grid="f19_g17" compset="BHIST" testmods="allactive/defaultio">
-    <machines>
-      <machine name="cheyenne" compiler="gnu" category="aux_cime_baselines"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="ERR" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">
-    <machines>
-      <machine name="edison" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="NCK" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">
-    <machines>
-      <machine name="edison" compiler="intel" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 02:00 </option>
-    </options>
-  </test>
-  <test name="NCK" grid="f19_g17" compset="B1850" testmods="allactive/defaultiomi">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 02:00 </option>
-    </options>
-  </test>
-  <test name="ERS_D" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 06:00 </option>
-    </options>
-  </test>
-  <test name="IRT" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">
-    <machines>
-      <machine name="bluewaters" compiler="pgi" category="prebeta"/>
-    </machines>
-    <options>
-       <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="IRT" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
-    <machines>
-      <machine name="bluewaters" compiler="pgi" category="prealpha"/>
-      <machine name="edison" compiler="cray" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:40 </option>
-    </options>
-  </test>
-  <test name="IRT" grid="f09_g17" compset="BRCP85L45BGCR" testmods="allactive/defaultio">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="IRT_Ld7" grid="f09_g17" compset="BHIST" testmods="allactive/defaultio">
-    <machines>
-      <machine name="bluewaters" compiler="pgi" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="SMS_Ld1" grid="f09_g17" compset="BW1850" testmods="allactive/default">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
+      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test name="SMS_Ld1" grid="f09_g17" compset="BWsc1850" testmods="allactive/default">
+  <test name="SMS_D_Ld1" grid="f09_tn14" compset="NHISTfrc2" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="SMS_Ld1" grid="f09_g17" compset="BWscHIST" testmods="allactive/default">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="SMS_Ld1" grid="f09_g17" compset="BW1PCTcmip6" testmods="allactive/defaultio_min">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
+      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test name="SMS_D_Ld1" grid="f09_g17" compset="BWCO2x4cmip6" testmods="allactive/defaultio_min">
+  <test name="PFS" grid="f09_tn14" compset="NHISTfrc2" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
+      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
     </machines>
     <options>
       <option name="wallclock"> 01:00 </option>
-    </options>
-  </test>
-  <test name="SMS_Ld1" grid="f09_g17" compset="BWHIST" testmods="allactive/default">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 01:00 </option>
-    </options>
-  </test>
-  <test name="IRT_Ld5" grid="f09_g17" compset="BWHISTcmip6" testmods="allactive/defaultio_min">
-    <machines>
-      <machine name="cheyenne" compiler="gnu" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 01:00 </option>
-    </options>
-  </test>
-  <test name="SMS_Ld5" grid="f19_g17" compset="BWma1850" testmods="allactive/default">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 01:00 </option>
-    </options>
-  </test>
-  <test name="SMS_Ld1" grid="f09_g17" compset="BWma1850" testmods="allactive/default">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="bwaccm"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 01:00 </option>
-    </options>
-  </test>
-  <test name="IRT_Ld7" grid="f09_g17" compset="BHIST" testmods="allactive/defaultio">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 01:00 </option>
-    </options>
-  </test>
-  <test name="ERS_Ld5" grid="f19_g17" compset="E1850L45TEST" testmods="cice/default">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="ERS_Ld7" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">
-    <machines>
-      <machine name="bluewaters" compiler="pgi"   category="prebeta"/>
-      <machine name="cheyenne"   compiler="intel" category="prealpha"/>
-      <machine name="hobart"     compiler="pgi"   category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="ERS_Ld5" grid="f09_g17" compset="BCO2x4cmip6" testmods="allactive/defaultio_min">
-    <machines>
-      <machine name="bluewaters" compiler="pgi"   category="prebeta"/>
-      <machine name="cheyenne"   compiler="intel" category="prealpha"/>
-      <machine name="hobart"     compiler="pgi"   category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="ERS_Ld5" grid="f09_g17" compset="BWCO2x4cmip6" testmods="allactive/defaultio_min">
-    <machines>
-      <machine name="cheyenne"   compiler="gnu" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-      <option name="comment">Restart test exercising BWCO2x4cmip6</option>
-    </options>
-  </test>
-    <test name="ERS_Ld5" grid="f09_g17" compset="B1PCTcmip6" testmods="allactive/defaultio_min">
-    <machines>
-      <machine name="bluewaters" compiler="pgi"   category="prebeta"/>
-      <machine name="cheyenne"   compiler="intel" category="prealpha"/>
-      <machine name="hobart"     compiler="pgi"   category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="ERS_Ld7" grid="f09_g17" compset="BHIST" testmods="allactive/defaultio">
-    <machines>
-      <machine name="bluewaters" compiler="pgi" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="ERS_Ld9" grid="ne120_g17" compset="B1850" testmods="allactive/defaultio">
-    <machines>
-      <machine name="edison" compiler="intel" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="IRT_N3_PM3_Ld7" grid="f19_g17" compset="BHIST" testmods="allactive/defaultio">
-    <machines>
-      <machine name="edison" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="cheyenne" compiler="gnu" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 02:00 </option>
-    </options>
-  </test>
-  <test name="ERS_Ld7" grid="f09_g17" compset="BRCP85L45BGCR" testmods="allactive/defaultio">
-    <machines>
-      <machine name="edison" compiler="intel" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="NCK_Ld5" grid="f19_g17" compset="BC5L45BGCR" testmods="allactive/defaultio">
-    <machines>
-      <machine name="cheyenne" compiler="gnu" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="NCK_Ld5" grid="f19_g17" compset="B1850G" testmods="allactive/cism/test_coupling">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 01:30 </option>
-    </options>
-  </test>
-  <test name="PET_PM" grid="f19_g17" compset="B1850" testmods="allactive/defaultiomi">
-    <machines>
-      <machine name="cheyenne" compiler="gnu" category="prealpha"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 01:30 </option>
-    </options>
-  </test>
-  <test name="PFS" grid="f09_g17" compset="B1850" testmods="allactive/default">
-    <machines>
-      <machine name="bluewaters" compiler="pgi" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:40 </option>
-    </options>
-  </test>
-  <test name="PFS" grid="f09_g17" compset="B1850" testmods="allactive/default">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:40 </option>
     </options>
   </test>
 
-  <test name="PFS" grid="f09_g17" compset="B1850" testmods="allactive/maxthroughputb">
+  <test name="ERS_Ld5" grid="f19_tn14" compset="N1850" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_perf"/>
+      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:40 </option>
+      <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test compset="FW1850" grid="f09_f09_mg17" name="PFS" testmods="allactive/maxthroughputfw">
+  <test name="SMS_D_Ld1" grid="f19_tn14" compset="N1850" testmods="allactive/defaultio">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_perf"/>
+      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
     </machines>
+    <options>
+      <option name="wallclock"> 01:00 </option>
+    </options>
+  </test>
+  <test name="PFS" grid="f19_tn14" compset="N1850">
+    <machines>
+      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00 </option>
+    </options>
+  </test>
+  <test name="ERS_Ld5" grid="f19_tn14" compset="NHIST" testmods="allactive/defaultio">
+    <machines>
+      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00 </option>
+    </options>
+  </test>
+  <test name="SMS_D_Ld1" grid="f19_tn14" compset="NHIST" testmods="allactive/defaultio">
+    <machines>
+      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00 </option>
+    </options>
+  </test>
+  <test name="PFS" grid="f19_tn14" compset="NHIST">
+    <machines>
+      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
+    </machines>
+    <options>
+      <option name="wallclock"> 01:00 </option>
+    </options>
   </test>
 
-  <test name="SMS_D" grid="f19_g17" compset="B1850" testmods="allactive/defaultio">
+  <test name="ERS_Ld5" grid="f19_tn14" compset="N1850esm" testmods="allactive/defaultio">
     <machines>
-      <machine name="edison" compiler="intel" category="prebeta"/>
+      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:30 </option>
+      <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test name="SMS_D" grid="f09_g17" compset="BHIST" testmods="allactive/defaultio">
+  <test name="SMS_D_Ld1" grid="f19_tn14" compset="N1850esm" testmods="allactive/defaultio">
     <machines>
-      <machine name="edison" compiler="intel" category="prebeta"/>
+      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:30 </option>
+      <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test name="SMS_Ld5" grid="f19_g17" compset="B1850G" testmods="allactive/cism/test_coupling">
+  <test name="PFS" grid="f19_tn14" compset="N1850esm">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="betzy" compiler="intel" category="noresm_prealpha"/>
     </machines>
     <options>
-      <option name="wallclock"> 00:30 </option>
+      <option name="wallclock"> 01:00 </option>
     </options>
   </test>
-  <test name="SMS_Ld5" grid="f09_g17" compset="B1850G" testmods="allactive/cism/test_coupling">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:30 </option>
-    </options>
-  </test>
-  <test name="SMS_Ld5" grid="f19_g17" compset="B1850G1" testmods="allactive/cism/test_coupling">
-    <machines>
-      <machine name="cheyenne" compiler="gnu" category="prebeta">
-        <options>
-          <option name="wallclock">0:30</option>
-          <option name="comment">Include a fully-coupled test with CISM1, mainly to make sure the PE layout works</option>
-        </options>
-      </machine>
-    </machines>
-  </test>
-  <test name="SMS_Ld1" grid="f19_g17" compset="B1850G" testmods="allactive/cism/test_coupling">
-    <machines>
-      <machine name="hobart" compiler="nag" category="prebeta"/>
-    </machines>
-    <options>
-      <option name="wallclock"> 00:45 </option>
-    </options>
-  </test>
-  <test name="SMS_Ld7" grid="f09_g17" compset="B1850" testmods="allactive/defaultio">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-    </machines>
-    <options>
-      <option name="wallclock">  00:30 </option>
-    </options>
-  </test>
-  <test name="SMS_D_Ld1" grid="f09_g17" compset="B1850cmip6" testmods="allactive/defaultio_min">
-    <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha">
-        <options>
-          <option name="wallclock">0:30</option>
-          <option name="comment">Debug test exercising B1850cmip6</option>
-        </options>
-      </machine>
-    </machines>
-  </test>
-  <test name="IRT_Ld5" grid="f09_g17" compset="BHISTcmip6" testmods="allactive/defaultio_min">
-    <machines>
-      <machine name="cheyenne" compiler="gnu" category="prealpha">
-        <options>
-          <option name="wallclock">0:30</option>
-          <option name="comment">Debug test exercising B1850cmip6</option>
-        </options>
-      </machine>
-    </machines>
-  </test>
-  <test name="ERS_Ld5" grid="f09_g17" compset="BWHISTcmip6" testmods="allactive/defaultio_min">
-    <machines>
-      <machine name="cheyenne" compiler="gnu" category="prebeta">
-        <options>
-          <option name="wallclock">0:30</option>
-          <option name="comment">Restart test exercising BW1850cmip6</option>
-        </options>
-      </machine>
-    </machines>
-  </test>
+
 </testlist>


### PR DESCRIPTION
Update `noresm2` branch in preparation for new release noresm2.0.8

- noresm2.0.8 will be bit-wise compatible with earlier noresm2.0.X releases
- noresm2.0.8 use Betzy tool chain 2022a, replacing 2020a
- noresm2.0.8 is a direct  descendant of [release-noresm2.0.6](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.0.6)
- noresm2.0.8 in not a direct descendant of [release-noresm2.0.7](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.0.7), which was tagged on the `noresm2_1_develop` branch.
  + `testlist_allactive.xml` is updated from `noresm2_1_develop` with this PR.
  + A change in `config_pes.xml` introduced on the `noresm2` branch in [commit 18b0863](https://github.com/NorESMhub/NorESM/commit/18b0863b17e86f02908efbbb354d675edf31b07a) has been retained.