### PR TITLE
Update NorESM2.1 cime tag for new tool chain on Betzy.

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -13,7 +13,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_NorESM2_3_r3
+tag = cime5.6.10_NorESM2_3_r4
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -13,7 +13,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_NorESM2_1_r4
+tag = cime5.6.10_NorESM2_3_r3
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime


### PR DESCRIPTION
This PR updates the cime tag to `cime5.6.10_NorESM2_3_r4`, which provides the 2022a tool chain on Betzy.
This change is needed as the 2020a tool chain will be removed from Betzy.
- Update also tool chain for CPRNC needed for regression tests.
- Following this update, a new `noresm2.1.2` will be released.