### PR TITLE
Update noresm2_3_develop cime tag to use 2022a tool chain on Betzy.

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -14,7 +14,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_NorESM2_3_r2
+tag = cime5.6.10_NorESM2_3_r3
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -14,7 +14,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_NorESM2_3_r3
+tag = cime5.6.10_NorESM2_3_r4
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime


### PR DESCRIPTION
This PR changes the cime tag to `cime5.6.10_NorESM2_3_r4`, which use the 2022a tool chain on Betzy.

