### PR TITLE
Noresm2 - change BLOM tag to v1.4.2

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -51,7 +51,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = v1.4.0
+tag = v1.4.2
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -51,7 +51,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = v1.3.0
+tag = v1.4.0
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The NorESM-2.0 documentation: https://noresm-docs.readthedocs.io/en/noresm2/
 - [release-noresm2.0.8](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.0.8)
     - Release of NorESM2.0.8, August 2024
     - Available to reproduce CMIP6 results of NorESM2
-    - Updated CIME with new tol chain modules on Betzy
+    - Updated CIME with new tool chain modules on Betzy
 
 - [release-noresm2.0.7](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.0.7)
     - Release of NorESM2.0.7, 15th of November 2023

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ NorESM2-LM and NorESM2-MM CMIP6 simulations
 The NorESM-2.0 documentation: https://noresm-docs.readthedocs.io/en/noresm2/
 
 ## Releases in noresm2
+- [release-noresm2.0.8](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.0.8)
+    - Release of NorESM2.0.8, August 2024
+    - Available to reproduce CMIP6 results of NorESM2
+    - Updated CIME with new tol chain modules on Betzy
+
 - [release-noresm2.0.7](https://github.com/NorESMhub/NorESM/releases/tag/release-noresm2.0.7)
     - Release of NorESM2.0.7, 15th of November 2023
     - Available to reproduce CMIP6 results of NorESM2


### PR DESCRIPTION
Change BLOM tag to `v1.4.2`.

BLOM `v1.4.0` introduces a major iHAMOCC code re-organization, new mechanisms to create namelist files, and some new optional features. See full [changelog](https://github.com/NorESMhub/BLOM/releases/tag/v1.4.0) for details.

BLOM `v1.4.1` add missing configurations for the ATRC option.

BLOM `v1.4.2` includes a minor update on the regression testing setup.