### PR TITLE
Change BLOM version to v1.6.2

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -52,7 +52,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = v1.6.1
+tag = v1.6.2
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom


### PR DESCRIPTION
BLOM `v1.6.2` includes a restructuring of testdefs for blom and hamocc.

This structural change is essentially equivalent to what was introduced in BLOM `v1.4.2` for `noresm2.0.8` and `v1.5.2` for  the `noresm2_1_develop` branch. 