### PR TITLE
Change BLOM version tag to v1.6.4

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -52,7 +52,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = v1.6.2
+tag = v1.6.3
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -52,7 +52,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = v1.6.3
+tag = v1.6.4
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom


### PR DESCRIPTION
Updates the tag on external BLOM dependecy M4AGO.
- v1.6.3: Workaround to avoid problems with repeated runs of `manage_externals`. (ref.: #556)
- The underlying problem remains, with `manage_externals` not handling tags on component external dependencies.
- v1.6.4: fix bug in iHAMOCC sediment flux initialization