### PR TITLE
Update tag for cime to cime5.6.10_NorESM2_3_r5

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -13,7 +13,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_NorESM2_3_r4
+tag = cime5.6.10_NorESM2_3_r5
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime


### PR DESCRIPTION
Update of cime tag required due to change in Betzy module.