### PR TITLE
Update BLOM tag to v1.6.5

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -52,7 +52,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = v1.6.4
+tag = v1.6.5
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom


### PR DESCRIPTION
Includes latest updates from BLOM, see [v1.6.5 release notes](https://github.com/NorESMhub/BLOM/releases/tag/v1.6.5)

The PR is answer changing for the optional extended nitrogen cycle, NOT for the default model version, since we fixed a bug in the sediment DNRA process.

The new tag brings in more HAMOCC output (dustfluxes) and makes switching between the various supported sinking schemes easier via a newly declared xml-switch `HAMOCC_SINKING_SCHEME` with options [WLIN,AGG,M4AGO,CONST], default value is/remains WLIN (the former switch HAMOCC_M4AGO was depreciated/removed).  