### PR TITLE
Fix CAM tag for running full chemistry

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,5 +1,5 @@
 [cam]
-tag = cam_noresm2_3_v1.0.0b
+tag = cam_noresm2_3_v1.0.0c
 protocol = git
 repo_url = https://github.com/NorESMhub/CAM
 local_path = components/cam


### PR DESCRIPTION
The final merge for the full chemistry PR (#520) left out the CAM tag which corrected the co2_cycle issue NorESMhub/CAM/#170.
This PR updates that tag.