### PR TITLE
noresm2_5_alpha08c: Update WW3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -136,7 +136,7 @@ fxDONOTUSEurl = https://github.com/ESCOMP/MOSART
 [submodule "ww3"]
 path = components/ww3
 url = https://github.com/NorESMhub/WW3_interface.git
-fxtag = ww3_interface_noresm0.0.15
+fxtag = ww3_interface_noresm0.0.16
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/WW3_interface.git
 


### PR DESCRIPTION
Update WW3 to ww3_interface_noresm0.0.16
This change is because the ww3_interface needed to be converted to use git-fleximod