### PR TITLE
Update blom tag to dev1.6.1.10

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -80,7 +80,7 @@ fxDONOTUSEurl = https://github.com/NorESMHub/NorESM_share
 [submodule "blom"]
 path = components/blom
 url = https://github.com/NorESMhub/BLOM.git
-fxtag = dev1.6.1.8
+fxtag = dev1.6.1.10
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/BLOM.git
 


### PR DESCRIPTION
This PR pulls inn the latest updates from blom.

**Testing this PR**
- [ ] Run test `allactive` for `noresm2_5_alpha08c` with the blom tag `dev1.6.1.10`
- [ ] Run test `blom` for `noresm2_5_alpha08c` with the blom tag `dev1.6.1.10`