### PR TITLE
noresm2_5_alpha08d: Update CAM to noresm2_5_017_cam6_4_041

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -87,7 +87,7 @@ fxDONOTUSEurl = https://github.com/NorESMhub/BLOM.git
 [submodule "cam"]
 path = components/cam
 url = https://github.com/NorESMhub/CAM.git
-fxtag = noresm2_5_016_cam6_4_041
+fxtag = noresm2_5_017_cam6_4_041
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/CAM.git
 


### PR DESCRIPTION
Summary: Update Oslo Aero to fix problems with updating changes from ESCOMP/CAM

Updated the tag for CAM to noresm2_5_017_cam6_4_041

Contributors: gold2718, mvertens
Reviewers: mvertens
Purpose of changes: Problems in OSLO_AERO port to cam6_4_041: https://github.com/NorESMhub/NorESM/issues/612
Github PR URL: https://github.com/NorESMhub/NorESM/pull/613
Changes made to build system: None
Changes made to the namelist: None
Changes to the defaults for the boundary datasets: None
Substantial timing or memory changes: None

Testing: See test results:
/cluster/work/users/mvertens/archive/nf1850_alpha08cam_ne30pg3_ne30pg3_mtn14_20241202/atm/hist

Issues addressed by this PR:
fixes #612 