### PR TITLE
Update BLOM tag to v1.4.4

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -51,7 +51,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = v1.4.2
+tag = v1.4.4
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom


### PR DESCRIPTION
This PR updates the BLOM tag from `v1.4.2`to `v1.4.4`, including changes from BLOM tags [v1.4.3](https://github.com/NorESMhub/BLOM/releases/tag/v1.4.3) and [v1.4.4](https://github.com/NorESMhub/BLOM/releases/tag/v1.4.4) to the `noresm2` branch.

* Namelist changes for running multiple instances of BLOM
* Update testdefs for HAMOCC
* Error message if use of old style `user_nl_blom` is detected
* Update python library for buildlib
* Update gitHub CI configuration