### PR TITLE
Update BLOM tag to v1.6.6

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -52,7 +52,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = v1.6.5
+tag = v1.6.6
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom


### PR DESCRIPTION
This PR updates the BLOM tag from `v1.6.5` to [v1.6.6](https://github.com/NorESMhub/BLOM/releases/tag/v1.6.6) for the `noresm2_3_develop` branch.

* Update testdefs for HAMOCC and BLOM
* Error message if use of old style `user_nl_blom` is detected
* Update python library for buildlib
* Update gitHub CI configuration