### PR TITLE
Update BLOM tag to v1.7.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -80,7 +80,7 @@ fxDONOTUSEurl = https://github.com/NorESMHub/NorESM_share
 [submodule "blom"]
 path = components/blom
 url = https://github.com/NorESMhub/BLOM.git
-fxtag = dev1.6.1.12
+fxtag = v1.7.0
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/BLOM.git
 


### PR DESCRIPTION
This tag version is intended for `noresm2_5_alpha09`, and potentially the NorESM2.5 release.