### PR TITLE
Update BLOM tag to v1.6.8

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -52,7 +52,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = v1.6.6
+tag = v1.6.8
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom


### PR DESCRIPTION
This PR updates the BLOM tag from `v1.6.6` to `v1.6.8`. The update includes:
- Update M4AGO version to tag `v1.1.1`.
- Change processor count for ERP test to P256

The update is not answer changing for default settings of BLOM/iHAMOCC.

**Testing**: New `allactive` baseline simulations

```
/cluster/shared/noresm/noresm_baselines/noresm_develop/noresm2_3_alpha01_v1.6.8

  PASS ERS_Ld5.f09_tn14.N1850frc2.betzy_intel.allactive-defaultio
  PASS ERS_Ld5.f09_tn14.NHISTfrc2.betzy_intel.allactive-defaultio
  PASS ERS_Ld5.f09_tn14.NHIST_tropstratchem.betzy_intel.allactive-defaultio
  PASS ERS_Ld5.f19_tn14.N1850.betzy_intel.allactive-defaultio
  PASS ERS_Ld5.f19_tn14.N1850esm.betzy_intel.allactive-defaultio
  PASS ERS_Ld5.f19_tn14.NHIST.betzy_intel.allactive-defaultio
  PASS PFS.f09_tn14.N1850frc2.betzy_intel.allactive-defaultio
  PASS PFS.f09_tn14.NHISTfrc2.betzy_intel.allactive-defaultio
  PASS PFS.f19_tn14.N1850.betzy_intel
  PASS PFS.f19_tn14.N1850esm.betzy_intel
  PASS PFS.f19_tn14.NHIST.betzy_intel
  PASS SMS_D_Ld1.f09_tn14.N1850frc2.betzy_intel.allactive-defaultio
  PASS SMS_D_Ld1.f09_tn14.NHISTfrc2.betzy_intel.allactive-defaultio
  PASS SMS_D_Ld1.f19_tn14.N1850.betzy_intel.allactive-defaultio
  PASS SMS_D_Ld1.f19_tn14.N1850esm.betzy_intel.allactive-defaultio
  PASS SMS_D_Ld1.f19_tn14.NHIST.betzy_intel.allactive-defaultio
```
