### PR TITLE
Update BLOM tag to v1.6.9

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -52,7 +52,7 @@ externals = Externals_POP.cfg
 required = False
 
 [blom]
-tag = v1.6.8
+tag = v1.6.9
 protocol = git
 repo_url = https://github.com/NorESMhub/BLOM
 local_path = components/blom


### PR DESCRIPTION
This fixes a bug in BLOM, caused by M4AGO being pulled in as external dependency in physics-only model settings.

M4AGO provides a general purpose particle sinking framework, currently used only when iHAMOCC is activated.

Fix issue #640 

I would like to tag `noresm2_3_alpha03` after merging this PR.