### PR TITLE
Update to cime5.6.10_NorESM2_3_r7 tag

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -13,7 +13,7 @@ local_path = components/cice
 required = True
 
 [cime]
-tag = cime5.6.10_NorESM2_3_r5
+tag = cime5.6.10_NorESM2_3_r7
 protocol = git
 repo_url = https://github.com/NorESMhub/cime
 local_path = cime


### PR DESCRIPTION
Includes updates for `cime5.6.10_NorESM2_3`:
- Fix CLMFORC paths on Betzy and Fram
- Bug fix for running with multi-driver mode