### PR TITLE
Turn on mediator history output for GLC to mediator

### DIFF
--- a/cime_config/testmods_dirs/allactive/defaultio/user_nl_cpl
+++ b/cime_config/testmods_dirs/allactive/defaultio/user_nl_cpl
@@ -1,0 +1,1 @@
+histaux_l2x1yrg = .true.


### PR DESCRIPTION
Turn on mediator history output for GLC to mediator input for the allactive prealpha_noresm tests.

fixes #636 