### PR TITLE
noresm3_0_alpha03b: BLOM updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -74,7 +74,7 @@ fxDONOTUSEurl = https://github.com/NorESMHub/NorESM_share.git
 [submodule "blom"]
 path = components/blom
 url = https://github.com/NorESMhub/BLOM.git
-fxtag = dev1.9.0.8
+fxtag = dev1.9.0.12
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/BLOM.git
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -74,7 +74,7 @@ fxDONOTUSEurl = https://github.com/NorESMHub/NorESM_share.git
 [submodule "blom"]
 path = components/blom
 url = https://github.com/NorESMhub/BLOM.git
-fxtag = dev1.9.0.7
+fxtag = dev1.9.0.8
 fxrequired = ToplevelRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/BLOM.git
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 ===============================================================
 Tag name: noresm3_0_alpha03b
-Date:
-One-line Summary:
+Date: 9 May 2025
+One-line Summary: Update BLOM shortwave absorption and default namelist
 
 Details:
  - Update BLOM tag to dev1.9.0.12
@@ -42,6 +42,19 @@ Summary of pre-tag testing:
  - prealpha_noresm : all tests PASS
 
 Summarize any change to answers:
+ - BASELINE diffs for all tests with BLOM, due to new default namelist for ALE method
+    DIFF ERI.ne30pg3_tn14.N1850.betzy_intel.allactive-defaultio
+    DIFF ERR.ne30pg3_tn14.N1850.betzy_intel.allactive-defaultio
+    DIFF ERS_D_Ld4.ne30pg3_tn14.N2N1850.betzy_intel.allactive-defaultio
+    DIFF ERS_Ld5.ne30pg3_tn14.N1850mam4.betzy_intel.allactive-defaultio
+    DIFF ERS.ne30pg3_tn14.N1850fates-nocomp.betzy_gnu.allactive-defaultio
+    DIFF SMS_D_Ld1.ne16pg3_tn14.N1850fates-nocomp.betzy_intel.allactive-reducedout
+    DIFF SMS_D_Ld1.ne16pg3_tn14.N1850fates-sp.betzy_gnu.allactive-defaultio
+    DIFF SMS_D_Ld1.ne30pg3_tn14.N1850.betzy_intel.allactive-defaultio
+    DIFF SMS_D_Ld1.ne30pg3_tn14.N1850clmbgc.betzy_intel.allactive-defaultio
+    DIFF SMS_D_Ld1.ne30pg3_tn14.N1850fates-nocomp.betzy_intel.allactive-defaultio
+    DIFF SMS_D_Ld1.ne30pg3_tn14.N1850fates-sp.betzy_gnu.allactive-defaultio
+
 
 ===============================================================
 Tag name: noresm3_0_alpha03a

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,7 +5,7 @@ One-line Summary: Update BLOM shortwave absorption and default namelist
 
 Details:
  - Update BLOM tag to dev1.9.0.12
-   + Includ modified shortwave absorption module
+   + Include modified shortwave absorption module
    + New default namelist for ALE method
    + Bug fix for input file names
    + Set default atm. N2O concentration to pre-industrial value

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,44 @@
 ===============================================================
+Tag name: noresm3_0_alpha04
+Date:
+One-line Summary:
+
+Details:
+ - Update BLOM tag to dev1.9.0.8
+   + Includ modified shortwave absorption module
+   + Bug fix for input file names
+
+List all component tags that were used to create noresm tag:
+ - parallelio : NCAR/ParallelIO             : pio2_6_2
+ - ccs_config : NorESMhub/ccs_config_noresm : ccs_config_noresm0.0.45
+ - cime       : NorESMhub/cime              : cime6.1.73_noresm_v0
+ - share      : NorESMHub/NorESM_share      : share1.1.9_noresm_v0
+ - blom       : NorESMhub/BLOM              : dev1.9.0.8
+ - cam        : NorESMhub/CAM               : noresm3_0_002_cam6_4_070
+ - cdeps      : NorESMhub/CDEPS             : cdeps1.0.70_noresm_v4
+ - cice6      : NorESMhub/NorESM_CICE       : cesm_cice6_5_0_20240702_noresm_v3
+ - cism       : NorESMhub/CISM-wrapper      : cismwrap_2_2_006_noresm_v0
+ - clm        : NorESMhub/CTSM              : ctsm5.3.034_noresm_v5
+    - fates   : NorESMhub/fates             : sci.1.82.3_api.39.0.0_noresm_v2
+ - cmeps      : NorESMhub/CMEPS             : cmeps1.0.39_noresm_v1
+ - mosart     : ESCOMP/MOSART               : mosart1.1.08
+ - ww3        : NorESMhub/WW3_interface     : ww3_interface_noresm0.0.17
+ - pycect     : NCAR/PyCECT                 : 3.2.2
+
+Bugs fixed:
+ - Support 512 character length input files for BLOM/iHAMOCC
+
+Describe any changes made to scripts/build system: NA
+
+Describe any substantial timing or memory changes: NA
+
+Code reviewed by:
+
+Summary of pre-tag testing:
+
+Summarize any change to answers:
+
+===============================================================
 Tag name: noresm3_0_alpha03a
 Date: 5 May 2025
 One-line Summary: Reduced output usermod, BLOM and CTSM updates

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,19 +1,22 @@
 ===============================================================
-Tag name: noresm3_0_alpha04
+Tag name: noresm3_0_alpha03b
 Date:
 One-line Summary:
 
 Details:
- - Update BLOM tag to dev1.9.0.8
+ - Update BLOM tag to dev1.9.0.12
    + Includ modified shortwave absorption module
+   + New default namelist for ALE method
    + Bug fix for input file names
+   + Set default atm. N2O concentration to pre-industrial value
+   + Correct CaCO3 dissolution rate constant
 
 List all component tags that were used to create noresm tag:
  - parallelio : NCAR/ParallelIO             : pio2_6_2
  - ccs_config : NorESMhub/ccs_config_noresm : ccs_config_noresm0.0.45
  - cime       : NorESMhub/cime              : cime6.1.73_noresm_v0
  - share      : NorESMHub/NorESM_share      : share1.1.9_noresm_v0
- - blom       : NorESMhub/BLOM              : dev1.9.0.8
+ - blom       : NorESMhub/BLOM              : dev1.9.0.12
  - cam        : NorESMhub/CAM               : noresm3_0_002_cam6_4_070
  - cdeps      : NorESMhub/CDEPS             : cdeps1.0.70_noresm_v4
  - cice6      : NorESMhub/NorESM_CICE       : cesm_cice6_5_0_20240702_noresm_v3
@@ -35,6 +38,8 @@ Describe any substantial timing or memory changes: NA
 Code reviewed by:
 
 Summary of pre-tag testing:
+ - aux_blom_noresm : tests PASS (except the "expected FAIL" tests)
+ - prealpha_noresm : all tests PASS
 
 Summarize any change to answers:
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -35,7 +35,7 @@ Describe any changes made to scripts/build system: NA
 
 Describe any substantial timing or memory changes: NA
 
-Code reviewed by:
+Code reviewed by: Steve Goldhaber, Matvey Debolskiy
 
 Summary of pre-tag testing:
  - aux_blom_noresm : tests PASS (except the "expected FAIL" tests)


### PR DESCRIPTION
Details:
 - Update BLOM tag to dev1.9.0.12
   + Include modified shortwave absorption module
   + New default namelist for ALE method
   + Bug fix for input file names
   + Set default atm. N2O concentration to pre-industrial value
   + Correct CaCO3 dissolution rate constant

Bugs fixed:
 - Support 512 character length input files for BLOM/iHAMOCC

Summary of pre-tag testing:
 - aux_blom_noresm : tests PASS (except the "expected FAIL" tests)
 - prealpha_noresm : all tests PASS

